### PR TITLE
Interpolate GPS time for messages that only have the host time.

### DIFF
--- a/gnss_analysis/tables.py
+++ b/gnss_analysis/tables.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+"""Interpolation utilities for Pandas tables.
+
+"""
+
+import pandas as pd
+
+USEC_TO_SEC = 10**-6
+MSEC_TO_SEC = 10**-3
+
+import warnings
+warnings.filterwarnings('ignore', category=pd.io.pytables.PerformanceWarning)
+
+
+def interpolate_gpst_model(df_gps):
+  """Produces a linear mapping between the host's log offset (seconds)
+  and GPS offset (seconds) from the beginning of the log. Assumes that
+  the first GPS time as the initial GPS time.
+
+  Parameters
+  ----------
+  host_offset : pandas.DataFrame
+
+  Returns
+  ----------
+  pandas.stats.ols.OLS
+
+  """
+  init_gps_t = pd.to_datetime(df_gps['index'][0])
+  gps_offset = pd.to_datetime(df_gps['index']) - init_gps_t
+  gps_offset_y = gps_offset.dt.seconds + gps_offset.dt.microseconds*USEC_TO_SEC
+  log_offset_x = df_gps.host_offset*MSEC_TO_SEC
+  return pd.ols(y=gps_offset_y, x=log_offset_x, intercept=True)
+
+
+def apply_gps_time(host_offset, init_offset, init_date, model):
+  """Interpolates a GPS datetime based on a record's host log offset.
+
+  Parameters
+  ----------
+  host_offset : int
+    Millisecond offset since beginning of log.
+  init_offset : int
+    host_offset of the first GPS time in the table.
+  model : pandas.stats.ols.OLS
+    Pandas OLS model mapping host offset to GPS offset
+
+  Returns
+  ----------
+  pandas.tslib.Timestamp
+
+  """
+  gps_offset = model.beta.x * (host_offset - init_offset) + model.beta.intercept
+  return init_date + pd.Timedelta(seconds=gps_offset)
+
+
+def get_gps_time_col(store, tabs):
+  """Given an HDFStore and a list of tables in that HDFStore,
+  interpolates GPS times for the desired tables and inserts the
+  appropriate columns in the table.
+
+  Parameters
+  ----------
+  store : pandas.HDFStore
+    Pandas HDFStore
+  tabs : list
+    List of tables to interpolate for
+
+  """
+  idx = store.rover_spp.T.host_offset.reset_index()
+  model = interpolate_gpst_model(idx)
+  init_offset = store.rover_spp.T.host_offset[0]
+  init_date = store.rover_spp.T.index[0]
+  f= lambda t1: apply_gps_time(t1*MSEC_TO_SEC, init_offset, init_date, model)
+  gpst_key = 'approx_gps_time'
+  for tab in tabs:
+    if isinstance(store[tab], pd.DataFrame):
+      dft = store[tab].T
+      dft[gpst_key] = store[tab].T.host_offset.apply(f)
+      store[tab] = dft.T
+    elif isinstance(store[tab], pd.Panel):
+      x = store[tab].transpose(2, 0, 1)
+      y = {}
+      for prn in x.items:
+        y[prn] = x[prn, :, 'host_offset'].dropna().apply(f)
+      ans = store[tab].transpose(1, 2, 0)
+      ans[gpst_key] = pd.DataFrame(y).T
+      store[tab] = ans.transpose(2, 0, 1)

--- a/gnss_analysis/tools/interpolate.py
+++ b/gnss_analysis/tools/interpolate.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Ian Horn <ian@swiftnav.com>
+#          Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+"""The interpolate tool takes generated HDF5 output from records2table
+and fills in derived or interpolated observation quantities.
+
+For example, passing an HDF5 store that looks like
+<class 'pandas.io.pytables.HDFStore'>
+File path: /home/mookerji/projects/swift/gnss-analysis/test2.hdf5
+/base_obs                   wide         (shape->[6948,6,9])
+/ephemerides                wide         (shape->[1,28,10])
+/rover_iar_state            frame        (shape->[3,1487])
+/rover_logs                 frame        (shape->[1,3907])
+/rover_obs                  wide         (shape->[6954,6,10])
+/rover_rtk_ecef             frame        (shape->[9,14112])
+/rover_rtk_ned              frame        (shape->[10,14112])
+/rover_spp                  frame        (shape->[9,14116])
+/rover_tracking             wide         (shape->[7370,5,32])
+
+will decorate the rover_iar_state, rover_logs, and rover_tracking
+messages with their interpolated GPS time. Each will have a new column
+titled 'approx_gps_time'.
+
+"""
+
+from gnss_analysis.tables import get_gps_time_col
+import pandas as pd
+
+def main():
+  import argparse
+  import sys
+  parser = argparse.ArgumentParser(description='Swift Nav derive/interpolate obs.')
+  parser.add_argument('file',
+                      help='Specify the log file to use.')
+  parser.add_argument('-n', '--num_records',
+                      nargs=1,
+                      default=[None],
+                      help='Number of GPS observation records to process.')
+  parser.add_argument('-v', '--verbose',
+                      action='store_true',
+                      help='Verbose output.')
+  gps_time_tabs = ['rover_iar_state', 'rover_logs', 'rover_tracking']
+  # TODO (Buro): Add in handling for explicit overwrites. Currently,
+  # this will fill in and overwrite (specifically sdiffs, etc.) that
+  # you might have.
+  #
+  # parser.add_argument('-o', '--output',
+  #                     nargs=1,
+  #                     default=[None],
+  #                     help='Test results output filename')
+  # parser.add_argument('-w', '--overwrite',
+  #                     action='store_true'
+  #                     help='Overwrite .')
+  args = parser.parse_args()
+  log_datafile = args.file
+  num_records = args.num_records[0]
+  verbose = args.verbose
+  with pd.HDFStore(log_datafile) as store:
+    try:
+      if verbose:
+        print "Verbose output specified..."
+        print "Loading table %s ." % str(store)
+        print "Interpolating times for tables %s." % ', '.join(gps_time_tabs)
+      get_gps_time_col(store, gps_time_tabs)
+    except (KeyboardInterrupt, SystemExit):
+      print "Exiting!"
+      sys.exit()
+    finally:
+      store.close()
+
+if __name__ == "__main__":
+  main()

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+"""Basic integration tests for pandas GPS time interpolation
+utilities.
+
+"""
+
+from pandas.tslib import Timestamp, Timedelta
+import gnss_analysis.tables as t
+import numpy as np
+import os
+import pandas as pd
+
+
+def test_interpolate_gps_time():
+  filename = "data/serial-link-20150429-163230.log.json.hdf5"
+  assert os.path.isfile(filename)
+  with pd.HDFStore(filename) as store:
+    idx = store.rover_spp.T.host_offset.reset_index()
+    model = t.interpolate_gpst_model(idx)
+    assert isinstance(model, pd.stats.ols.OLS)
+    assert np.allclose([model.beta.x, model.beta.intercept],
+                       [1.00000368376, -64.2579561376])
+    init_offset = store.rover_spp.T.host_offset[0]
+    init_date = store.rover_spp.T.index[0]
+    l = store.rover_logs.T.host_offset.tolist()
+    start = t.apply_gps_time(l[0]*t.MSEC_TO_SEC, init_offset, init_date, model)
+    assert start == Timestamp("2015-04-29 05:41:47.035327")
+    end = t.apply_gps_time(l[-1]*t.MSEC_TO_SEC, init_offset, init_date, model)
+    assert end == Timestamp("2015-04-29 06:06:38.220820")
+    f = lambda t1: t.apply_gps_time(t1*t.MSEC_TO_SEC, init_offset, init_date, model)
+    dates = store.rover_logs.T.host_offset.apply(f)
+    assert pd.DatetimeIndex(dates).is_monotonic_increasing
+    assert dates.shape == (2457,)
+
+def test_gps_time_col():
+  filename = "data/serial-link-20150429-163230.log.json.hdf5"
+  assert os.path.isfile(filename)
+  with pd.HDFStore(filename) as store:
+    tables = ['rover_iar_state', 'rover_logs', 'rover_tracking']
+    t.get_gps_time_col(store, tables)
+    gpst = store.rover_iar_state.T.approx_gps_time
+    assert gpst.shape == (1487,)
+    assert pd.DatetimeIndex(gpst).is_monotonic_increasing
+    gpst = store.rover_logs.T.approx_gps_time
+    assert gpst.shape == (2457,)
+    assert pd.DatetimeIndex(gpst).is_monotonic_increasing
+    gpst = store.rover_tracking[:, 'approx_gps_time', :]
+    assert gpst.shape == (32, 7248)


### PR DESCRIPTION
In some cases, we want to approximately sync logging, tracking, iar
messages, etc. with RTK/SPP position solutions events that do have
accompanying GPS times. This uses the host offsets from SBP messages
logs to interpolate column. Also accessible via the command line.

/cc @imh @fnoble @henryhallam