### PR TITLE
Deprecate data io (and fix other tests)

### DIFF
--- a/gnss_analysis/data_io.py
+++ b/gnss_analysis/data_io.py
@@ -9,6 +9,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+import warnings
 import pandas as pd
 import numpy as np
 from pynex.dd_tools import sds_with_lock_counts
@@ -18,6 +19,8 @@ from swiftnav.gpstime import *
 from swiftnav.pvt import calc_PVT
 from swiftnav.track import NavigationMeasurement
 
+warnings.warn("gnss_analysis.data_io will be deprecated shortly",
+              FutureWarning)
 
 def fill_in_ephemerides(ephs):
   """Fills in an ephemeris Panel so that there are no missing
@@ -181,6 +184,9 @@ def mk_sdiffs_and_abs_pos(ephs, rover_obs, base_obs):
     The base receiver's single point position.
 
   """
+  warnings.warn("mk_sdiffs_and_abs_pos has been deprecated in favor"
+                " of observations.fill_observations",
+                FutureWarning)
   ephs = ephs.ix[:, [el for el in ephs.major_axis if el != 'payload'], :]
   obs = sds_with_lock_counts(rover_obs, base_obs)
   j = obs.transpose(1, 0, 2).join(

--- a/gnss_analysis/dgnss.py
+++ b/gnss_analysis/dgnss.py
@@ -16,7 +16,7 @@
 """
 
 from gnss_analysis.constants import MIN_SATS
-from swiftnav.single_diff import SingleDiff
+from swiftnav.observation import SingleDiff
 import numpy as np
 import pandas as pd
 import swiftnav.dgnss_management as mgmt

--- a/gnss_analysis/observations.py
+++ b/gnss_analysis/observations.py
@@ -21,17 +21,19 @@ vector refactorized later.
 
 """
 
-from gnss_analysis.constants import *
-from swiftnav.ephemeris import Ephemeris, calc_sat_state
-from swiftnav.gpstime import GpsTime
-from swiftnav.pvt import calc_PVT
-from swiftnav.single_diff import SingleDiff
-from swiftnav.track import NavigationMeasurement
+import time
 import datetime
 import numpy as np
 import pandas as pd
 import swiftnav.gpstime as gpstime
-import time
+
+from swiftnav.pvt import calc_PVT
+from swiftnav.track import NavigationMeasurement
+from swiftnav.gpstime import GpsTime
+from swiftnav.ephemeris import Ephemeris, calc_sat_state
+from swiftnav.observation import SingleDiff
+
+from gnss_analysis.constants import *
 
 ###############################################################################
 # Misc. libswiftnav object constructors


### PR DESCRIPTION
Pretty much everything in data_io is duplicated in observations.py.  That was very confusing, probably better to remove it.  This change introduces a deprecation warning, then when we're confident that we don't need the module we can completely remove it.

This change also fixes test caused by improper imports in observations.py

@mookerji @kovach @benjamin0 