### PR TITLE
DGNSS Tooling

### DIFF
--- a/gnss_analysis/io/sbp_utils.py
+++ b/gnss_analysis/io/sbp_utils.py
@@ -10,6 +10,18 @@ from gnss_analysis import constants as c
 from gnss_analysis import time_utils
 
 
+def normalize(sbp_obs):
+  """
+  Makes changes to an sbp observation in order to conform with
+  industry standard (RINEX) conventions.
+  """
+  # TODO: Eventually sbp logs will already conform to RINEX
+  #   conventions, in which case we can remove this function.
+  sbp_obs = sbp_obs.copy()
+  sbp_obs['carrier_phase'] = -sbp_obs['carrier_phase']
+  return sbp_obs
+
+
 def get_source(msg):
   """
   Determines if a message originated at the rover or base station.

--- a/gnss_analysis/propagate.py
+++ b/gnss_analysis/propagate.py
@@ -1,0 +1,136 @@
+# Copyright (C) 2016 Swift Navigation Inc.
+# Contact: Alex Kleeman <alex@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+"""
+propagate.py
+
+Contains a few (simple) algorithms used to take a set of observations
+made by some receiver and use them to infer what the same receiver would
+have observed at some future time.  This process is referred to as
+propagation.
+"""
+
+import numpy as np
+
+from gnss_analysis import ephemeris
+from gnss_analysis import constants as c
+from gnss_analysis import time_utils
+
+
+def line_of_sight_distance(sat, position_ecef, tof):
+  """
+  A convenience function which applies sagnac correction, then
+  computes the range (in meters) from position_ecef 
+  to each satellite in `sat`.
+  """
+  los_pos = ephemeris.sagnac_rotation(sat[['sat_x', 'sat_y', 'sat_z']],
+                                      time_of_flight=tof)
+  return np.linalg.norm(los_pos - position_ecef, axis=1)
+
+
+def resolve_toa_tot(sat, new_toa, new_tot, position_ecef):
+  if new_tot is None and new_toa is None:
+    raise ValueError("Expected either new_toa or new_tot")
+  if new_tot is not None and new_toa is not None:
+    raise ValueError("Expected either new_toa or new_tot (but got both)")
+
+  if new_tot is None and new_toa is not None:
+    # if new_toa was provided, we back solve for the new time of transmit
+    new_tot = ephemeris.time_of_transmission(sat, new_toa, position_ecef)
+  elif new_toa is None and new_tot is not None:
+    # if new_tot was provicded we forward solve for the new time of arrival
+    new_toa = ephemeris.time_of_arrival(sat, new_tot, position_ecef)
+  else:
+    raise ValueError("Expected either new_toa or new_tot but not both")
+
+  return new_toa, new_tot
+
+
+def doppler_propagate(position_ecef, satellite,
+                      new_toa=None, new_tot=None,
+                      clock_error_rate=0.):
+  """
+  This propagation algorithm uses the doppler, or time derivative of the
+  carrier phase, (in units of cycles/sec) to compute a first order
+  approximation of the change in range to each satellite.
+  
+  L' = L + dt * doppler
+  P' = P + dt * doppler * wavelength
+  
+  """
+  # copy so we don't overwrite
+  sat = satellite.copy()
+  # determine the new time of arrival and transmission.
+  new_toa, new_tot = resolve_toa_tot(sat, new_toa, new_tot, position_ecef)
+  # How
+  delta_t = time_utils.seconds_from_timedelta(new_toa - sat['time'])
+  # the change in carrier phase is simply the time difference times doppler
+  sat['carrier_phase'] += delta_t * sat['doppler']
+  # the change in range is the same as change in carrier_phase times wavelength
+  delta_dist = delta_t * sat['doppler'] * c.GPS_L1_LAMBDA
+  # the pseudorange gets pushed forward by delta distance
+  sat['raw_pseudorange'] += delta_dist
+  sat['pseudorange'] += delta_dist
+  sat['time'] = new_toa
+  sat['tot'] = new_tot
+  return sat
+
+
+def delta_tof_propagate(position_ecef, satellite, new_toa=None, new_tot=None):
+  """
+  Takes a single satellite observation taken from a known position and
+  propagates it to the target time of arrival or time of transmission
+  by looking at the difference in time of flight.
+
+  Parameters
+  ----------
+  position_ecef : tuple of floats
+    The position of the receiver in earth centric coordinates.
+    The tuple is expected to contain x, y, z values in meters.
+  satellite : pd.DataFrame
+    A set of satellite observations taken at some time.
+  new_toa : datetime64
+    The desired time of arrival
+  new_tot : datetime64
+    The desired time of transmission.
+    
+  Returns
+  -------
+  satellite : pd.Series
+    The satellite observations if they had been made at gpst.
+  """
+  # copy so we don't overwrite
+  sat = satellite.copy()
+  # determine the new time of arrival and transmission.
+  new_toa, new_tot = resolve_toa_tot(sat, new_toa, new_tot, position_ecef)
+  # don't trust the TOT in sat since it may or may not include clock errors.
+  old_tot = ephemeris.time_of_transmission(sat, sat['time'], position_ecef)
+  old_tof = time_utils.seconds_from_timedelta(sat['time'] - old_tot)
+
+  # Compute the new time of flight.  Since we are possibly subtract two
+  # very small times, we first convert them to float seconds rather
+  # than dealing with timedelta objects which cap out at nano seconds.
+  new_tof = time_utils.seconds_from_timedelta(new_toa - new_tot)
+
+  # compute the change in physical distance between target and observation
+  delta_dist = (new_tof - old_tof) * c.GPS_C
+
+  # compute the new sat positions at time of transmit.
+  new_sat_state = ephemeris.calc_sat_state(sat, new_tot)
+  sat.update(new_sat_state)
+  # update the observations.
+  sat['carrier_phase'] += delta_dist / c.GPS_L1_LAMBDA
+  # the pseudorange gets pushed forward by delta distance
+  sat['raw_pseudorange'] += delta_dist
+  sat['pseudorange'] += delta_dist
+  sat['time'] = new_toa
+  sat['tot'] = new_tot
+
+  return sat

--- a/gnss_analysis/solution.py
+++ b/gnss_analysis/solution.py
@@ -218,6 +218,9 @@ def solution(states, dgnss_filter=None):
   order is somewhat reversed since on the piksi the solve is made,
   then (modified) observations are sent.  So this back first infers
   missing variables, then solves.
+  
+  Notes are added to indicate the actual order of what happens in
+  the equivalent thread on the piksi.
   """
 
   for state in states:
@@ -235,7 +238,7 @@ def solution(states, dgnss_filter=None):
     # already been done in the simulate module.
 
     # compute the single point position
-    rover_pos = single_point_position(state['rover'])
+    state['rover_pos'] = single_point_position(state['rover'])
 
     # TODO: WIP, plug in DGNSS filters here.
     # if a filter is present and we have enough base observations
@@ -248,8 +251,8 @@ def solution(states, dgnss_filter=None):
       dgnss_filter.update(state)
       # TODO: if low-latency make propagated sdiffs
       # NOTE: at this point on the piksi baseline messages are output.
-      bl = dgnss_filter.get_baseline(state)
-    # NOTE: only now are observations sent from the piksi
+      state['rover_pos']['baseline'] = dgnss_filter.get_baseline(state)
 
-    yield rover_pos
+    # NOTE: only now are observations sent from the piksi
+    yield state
 

--- a/gnss_analysis/synthetic.py
+++ b/gnss_analysis/synthetic.py
@@ -1,3 +1,7 @@
+#
+# TODO: This will soon be changed to better align with RINEX specifications
+#
+
 import numpy as np
 
 from gnss_analysis import ephemeris

--- a/gnss_analysis/synthetic.py
+++ b/gnss_analysis/synthetic.py
@@ -31,18 +31,8 @@ def observations_from_toa(ephemerides, location_ecef, toa,
   # ASSUMPTION: no noise!
   rover_clock_error = 0.
   actual_time_of_flight = time_utils.seconds_from_timedelta(toa - tot)
-  # TODO,
   raw_pseudorange = (actual_time_of_flight + rover_clock_error) * c.GPS_C
   carrier_phase = actual_time_of_flight * c.GPS_L1_HZ
-
-#   sat_state = ephemeris.calc_sat_state(ephemerides, tot)
-#   sat_velocity = sat_state[['sat_v_x', 'sat_v_y', 'sat_v_z']]
-#
-#   los_pos = ephemeris.sagnac_rotation(sat_state[['sat_x', 'sat_y', 'sat_z']],
-#                                       toa - tot)
-#   los_vect = los_pos - location_ecef
-#   unit_vect = los_vect / np.linalg.norm(los_vect, axis=1)[:, None]
-#   doppler = np.dot(sat_velocity.values.T, unit_vect) / c.GPS_L1_LAMBDA
 
   obs = ephemerides.copy()
   obs['raw_pseudorange'] = raw_pseudorange

--- a/gnss_analysis/synthetic.py
+++ b/gnss_analysis/synthetic.py
@@ -1,35 +1,77 @@
 import numpy as np
 
 from gnss_analysis import ephemeris
-from gnss_analysis import constants as c
 from gnss_analysis import time_utils
+from gnss_analysis import constants as c
+from gnss_analysis.io import sbp_utils
+
 
 def observations_from_toa(ephemerides, location_ecef, toa,
-                          *args, **kwdargs):
+                          rover_clock_error=0.,
+                          nav_time=None,
+                          include_sat_error=True):
   """
-  A covenience wrapper around observations_from_tot that
-  creates synthetic observations from a time of arrival (toa).
+  Creates synthetic observations from a time of arrival (toa).
+  This is done by backsolving for the time of transmission that
+  at each satellite that would have resulted in simultaneous
+  signal arrival at toa (time of arrival).
   
-  See observations_from_tot for details.
+  This is a lot simpler than observations_from_tot, but is
+  less closesly aligned with the way observations are created
+  on the piksi.
+  
+  See also: observations_from_tot
   """
+  # this method isn't capable of removing satellite error yet.
+  assert include_sat_error
   # compute the time of transmission had all the signals arrived
   # simultanousely at time of arrival
   tot = ephemeris.time_of_transmission(ephemerides, toa,
                                        location_ecef)
-  # the times will all be different since each satellite is
-  # a different distance.  Set the synchronized time of transmission
-  # to be the 10th second interval before all the transmission times,
-  # this ensures that all signals would have arrived before toa.
-  tot = {'wn': toa['wn'],
-         'tow': np.round(np.min(tot['tow']), 1)}
+  # ASSUMPTION: no noise!
+  rover_clock_error = 0.
+  actual_time_of_flight = time_utils.seconds_from_timedelta(toa - tot)
+  # TODO,
+  raw_pseudorange = (actual_time_of_flight + rover_clock_error) * c.GPS_C
+  carrier_phase = actual_time_of_flight * c.GPS_L1_HZ
+
+#   sat_state = ephemeris.calc_sat_state(ephemerides, tot)
+#   sat_velocity = sat_state[['sat_v_x', 'sat_v_y', 'sat_v_z']]
+#
+#   los_pos = ephemeris.sagnac_rotation(sat_state[['sat_x', 'sat_y', 'sat_z']],
+#                                       toa - tot)
+#   los_vect = los_pos - location_ecef
+#   unit_vect = los_vect / np.linalg.norm(los_vect, axis=1)[:, None]
+#   doppler = np.dot(sat_velocity.values.T, unit_vect) / c.GPS_L1_LAMBDA
+
+  obs = ephemerides.copy()
+  obs['raw_pseudorange'] = raw_pseudorange
+  obs['time'] = toa
+  # Carrier phase is currently set negative to emulate what happens on the
+  # piksi, but is later corrected by sbp_utils.normalize()
+  obs['carrier_phase'] = -carrier_phase
+  # doppler, cn0 and lock aren't simulated yet.
+  obs['raw_doppler'] = np.nan
+  obs['cn0'] = 30.
+  obs['lock'] = 0.
+  obs['ref_x'] = location_ecef[0]
+  obs['ref_y'] = location_ecef[1]
+  obs['ref_z'] = location_ecef[2]
+  obs['ref_t'] = toa
+  obs['ref_rover_clock_error'] = rover_clock_error
+
+  # note that we don't need to account for satellite clock error since
+  # it was not built into the observations.
+  obs = ephemeris.add_satellite_state(obs, ephemerides,
+                                      account_for_sat_error=False)
   # then return the synthetic observations based off our new tot.
-  return observations_from_tot(ephemerides, location_ecef, tot,
-                               *args, **kwdargs)
+  return sbp_utils.normalize(obs)
 
 
 def observations_from_tot(ephemerides, location_ecef, tot,
                           rover_clock_error=0.,
-                          account_for_sat_error=True):
+                          toa=None,
+                          include_sat_error=True):
   """
   Creates a set of observations (obs time and pseudoranges)
   based off a set of ephemeris information, a known location
@@ -44,37 +86,54 @@ def observations_from_tot(ephemerides, location_ecef, tot,
     A location given in earth center earth fixed coordinates.
   tot : datetime64
     The time of transmission in GPS time.
-  
+  rover_clock_error : float (optional)
+    The amount of time (in seconds) that the rover clock is
+    in advance of GPS system time.
+  toa : ddatetime64
+    The GPS system time that the observations are valid for.
+  include_sat_error : boolean
+    All satellites will transmit at a regular interval according to the
+    satellite clock (which is imperfect).  This means they will all
+    think they are transmitting simultaneously, but will actually
+    be asynchronous.  If this flag is True the satellite positions
+    will be taken to be their actual locations when the signal was
+    transmitted.  If False, the satellite positions are where the
+    satellite thinks it is when the signal is transmitted.
+    In otherwords setting include_sat_error to False is the equivalent
+    of assuming the satellite clocks are perfect.
+    
   Returns
   -------
   observations : pd.DataFrame
     A DataFrame holding a set of synthetic observations similar
     to what would be returned by simulate.simulate_from_log.
   """
-  #
   assert tot.dtype.kind == 'M'
-  sat_state = ephemeris.calc_sat_state(ephemerides, tot)
   # The satellites all transmit at what they think is the same
-  # time, but are actually off by 'clock_error' seconds
-  actual_tot = tot
-  actual_tot -= time_utils.timedelta_from_seconds(sat_state['sat_clock_error'])
+  # time, but are actually off by 'clock_error' seconds.  Here
+  # we create tot_sat, or the time of transmission according to
+  # the satellites
+  sat_state = ephemeris.calc_sat_state(ephemerides, tot)
+  tot_sat = tot
+  tot_sys = tot_sat - time_utils.timedelta_from_seconds(sat_state['sat_clock_error'])
   # compute the time when the signal would have arrived at the receiver
-  obs_toa = ephemeris.time_of_arrival(ephemerides,
-                                      actual_tot,
+  toa_sys = ephemeris.time_of_arrival(ephemerides,
+                                      tot_sys,
                                       location_ecef)
   # the actual time of flight is the time between when the
   # signal arrived and when it was actually transmitted
-  actual_time_of_flight = obs_toa - actual_tot
-  # Set the nav time (the time for which we're trying to solve)
-  # to be the next nearest tenth of a second after all the signals
-  # arrived at the rover
-  assert obs_toa.dtype == '<M8[ns]'
-  max_as_tenths = np.ceil(np.max(obs_toa).astype('int64') * 1e-8)
-  nav_time = (max_as_tenths * 1e8).astype('datetime64[ns]')
+  time_of_flight_sys = toa_sys - tot_sys
+  if toa is None:
+    # Set the time of arrival (the time for which we're trying to solve)
+    # to be the next nearest tenth of a second after all the signals
+    # arrived at the rover
+    assert tot.dtype == '<M8[ns]'
+    max_as_tenths = np.ceil(np.max(tot).astype('int64') * 1e-8)
+    toa = (max_as_tenths * 1e8).astype('datetime64[ns]')
 
   # In these next few steps we take a bunch of signals that arrived
   # asynchronously and nudge them forward so they look as they would
-  # have if they had all arrived exactly at nav_time.  This is similar to
+  # have if they had all arrived exactly at toa.  This is similar to
   # (BUT NOT EXACTLY) what happens on the piksi, which uses chip rate
   # to adjust the time of transmission.
   # TODO: make sure this is equivalent.
@@ -82,8 +141,8 @@ def observations_from_tot(ephemerides, location_ecef, tot,
   # The first order approximation of propagated time of transmission
   # is to simply push transmission times forward by the difference
   # between desired arrival time and actual.
-  dt = (nav_time - obs_toa)
-  propagated_tot = tot + dt
+  dt = (toa - toa_sys)
+  propagated_tot = tot_sat + dt
 
   # During that time the satellites would have moved slightly, changing
   # the time of flight (and in turn the time of transmission).  To
@@ -96,45 +155,60 @@ def observations_from_tot(ephemerides, location_ecef, tot,
   #   in libswiftnav/track.c:calc_navigation_measurements the
   #   satellite positions are computed at the expected GPS system time.
   #   verify which of these conventions is correct.
-  if account_for_sat_error:
-    actual_sat_state = ephemeris.calc_sat_state(ephemerides, actual_tot)
+  if include_sat_error:
+    actual_sat_state = ephemeris.calc_sat_state(ephemerides, tot_sys)
   else:
     actual_sat_state = sat_state
   sat_vel = actual_sat_state[['sat_v_x', 'sat_v_y', 'sat_v_z']].values
   sat_pos = actual_sat_state[['sat_x', 'sat_y', 'sat_z']].values
-  los_sat_pos = ephemeris.sagnac_rotation(sat_pos, actual_time_of_flight)
+  los_sat_pos = ephemeris.sagnac_rotation(sat_pos, time_of_flight_sys)
   # Then account for the rate of change in tot due to satellite velocity
   # ASSUMPTION: earth's rotation doesn't matter much here.  The difference
   # in los_pos would be O(dt * sat_vel / c) which should be extremelly small.
   dt_seconds = time_utils.seconds_from_timedelta(dt)
   new_pos = los_sat_pos + dt_seconds[:, None] * sat_vel
   new_tof = np.linalg.norm(new_pos - location_ecef, axis=1) / c.GPS_C
-  new_tof = time_utils.timedelta_from_seconds(new_tof)
   # if the new time of flight is longer we need to subract from the
   # transmission time in order to get signals which would have arrived
   # simultaneously.
-  propagated_tot -= (new_tof - actual_time_of_flight)
+  tof_sys_sec = time_utils.seconds_from_timedelta(time_of_flight_sys)
+  propagated_tot -= time_utils.timedelta_from_seconds(new_tof - tof_sys_sec)
 
-  # ASSUMPTION: no noise!
-  obs_tof_sec = time_utils.seconds_from_timedelta(nav_time - propagated_tot)
-
+  # ASSUMPTION: we've assumed there is no noise!
+  obs_tof_sec = time_utils.seconds_from_timedelta(toa - propagated_tot)
   raw_pseudorange = obs_tof_sec * c.GPS_C
   raw_pseudorange += rover_clock_error * c.GPS_C
-  wave_length = c.GPS_C / c.GPS_L1_HZ
-  carrier_phase = obs_tof_sec * c.GPS_C / wave_length
+
+  wave_length = c.GPS_L1_LAMBDA
+  tof_sec = time_utils.seconds_from_timedelta(time_of_flight_sys)
+  carrier_phase = tof_sec * c.GPS_C / wave_length
 
   obs = ephemerides.copy()
   obs['raw_pseudorange'] = raw_pseudorange
-  obs['time'] = nav_time
-  # carrier_pahse and doppler aren't created yet.
+  obs['time'] = toa
+  # Carrier phase is currently set negative to emulate what happens on the
+  # piksi, but is later corrected by sbp_utils.normalize()
+  obs['carrier_phase'] = -carrier_phase
+  # doppler, lock and cn0 aren't actually created yet.
   obs['raw_doppler'] = np.nan
-  obs['carrier_phase'] = carrier_phase
   obs['cn0'] = 30.
   obs['lock'] = 0.
   obs['ref_x'] = location_ecef[0]
   obs['ref_y'] = location_ecef[1]
   obs['ref_z'] = location_ecef[2]
-  obs['ref_t'] = nav_time
+  obs['ref_t'] = toa
   obs['ref_rover_clock_error'] = rover_clock_error
+  obs['ref_tot'] = propagated_tot
 
-  return obs
+  return sbp_utils.normalize(obs)
+
+
+def synthetic_state(ephemerides, rover_ecef, base_ecef, toa):
+  state = {'rover': observations_from_toa(ephemerides,
+                                          location_ecef=rover_ecef,
+                                          toa=toa),
+           'base': observations_from_toa(ephemerides,
+                                         location_ecef=base_ecef,
+                                         toa=toa),
+           'ephemeris': ephemerides}
+  return state

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
   print 'Please install or upgrade setuptools or pip to continue.'
   sys.exit(1)
 
-  
+
 INSTALL_REQUIRES = ['cython',
                     # These specific versions are required for
                     # a python environment that cooperates with
@@ -25,7 +25,6 @@ INSTALL_REQUIRES = ['cython',
                     'tables',
                     'matplotlib',
                     'sbp',
-                    'tables',
                     'scikits.statsmodels',
                     # this will have to be installed by either
                     # running `pip install -r requirements.txt`,
@@ -34,9 +33,9 @@ INSTALL_REQUIRES = ['cython',
                     # libswiftnav.
                     'swiftnav',
                     ]
-TEST_REQUIRES = ['pytest', 'mock']                  
-                  
-  
+TEST_REQUIRES = ['pytest', 'mock']
+
+
 setup(name='gnss_analysis',
       description='Analysis and Testing of libswiftnav RTK filters',
       version='0.24',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def synthetic_state(ephemerides):
   rover_ecef = locations.NOVATEL_ABSOLUTE
   base_ecef = locations.LEICA_ABSOLUTE
 
-  tot = ephemerides['time'] + np.timedelta64(np.int32(100), 's')
+  tot = ephemerides['time'] + np.timedelta64(100, 's')
 
   return synthetic.synthetic_state(ephemerides,
                                    rover_ecef, base_ecef,
@@ -102,7 +102,7 @@ def synthetic_stationary_state_sequence(ephemerides):
     base_ecef = locations.LEICA_ABSOLUTE
 
     for dt in time_steps:
-      toa = ephemerides['time'] + np.timedelta64(np.int32(100 + dt), 's')
+      toa = ephemerides['time'] + np.timedelta64(100 + dt, 's')
       state = synthetic.synthetic_state(ephemerides, rover_ecef,
                                         base_ecef, toa)
       state['base'] = ephemeris.add_satellite_state(state['base'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,4 +73,42 @@ def synthetic_observations(ephemerides):
 
   return synthetic.observations_from_tot(ephemerides, ref_loc, tot,
                                          rover_clock_error=0.,
-                                         account_for_sat_error=True)
+                                         include_sat_error=True)
+
+
+@pytest.fixture()
+def synthetic_state(ephemerides):
+  from gnss_analysis import synthetic, locations
+
+  rover_ecef = locations.NOVATEL_ABSOLUTE
+  base_ecef = locations.LEICA_ABSOLUTE
+
+  tot = ephemerides['time'] + np.timedelta64(np.int32(100), 's')
+
+  return synthetic.synthetic_state(ephemerides,
+                                   rover_ecef, base_ecef,
+                                   tot)
+
+@pytest.fixture()
+def synthetic_stationary_state_sequence(ephemerides):
+  """
+  Returns an iterator over synthetic states for which the rover and
+  base station are stationary.
+  """
+  from gnss_analysis import synthetic, locations, ephemeris
+
+  def iter_states(time_steps):
+    rover_ecef = locations.NOVATEL_ABSOLUTE
+    base_ecef = locations.LEICA_ABSOLUTE
+
+    for dt in time_steps:
+      toa = ephemerides['time'] + np.timedelta64(np.int32(100 + dt), 's')
+      state = synthetic.synthetic_state(ephemerides, rover_ecef,
+                                        base_ecef, toa)
+      state['base'] = ephemeris.add_satellite_state(state['base'],
+                                                    state['ephemeris'])
+      state['rover'] = ephemeris.add_satellite_state(state['rover'],
+                                                     state['ephemeris'])
+      yield state
+
+  return iter_states(np.linspace(0., 100., 1001.))

--- a/tests/test_dgnss.py
+++ b/tests/test_dgnss.py
@@ -1,0 +1,148 @@
+import pytest
+import random
+import numpy as np
+
+from pandas.util.testing import assert_frame_equal
+
+from swiftnav import dgnss_management
+
+from gnss_analysis import constants as c
+from gnss_analysis import dgnss, ephemeris, synthetic, locations
+
+
+def test_single_difference(synthetic_state):
+  """
+  This assumes that single_difference returns accurate differences
+  (which should be checked by test_make_propagated_single_differences)
+  and instead focuses on testing edge cases (dropped satellites etc.)
+  """
+  base_obs = ephemeris.add_satellite_state(synthetic_state['base'],
+                                            account_for_sat_error=False)
+  rover_obs = ephemeris.add_satellite_state(synthetic_state['rover'],
+                                            account_for_sat_error=False)
+  # Compute the full set of single differences.
+  expected_diffs = dgnss.single_difference(rover_obs, base_obs)
+
+  # now shuffle the observations and make sure satellites don't get confused.
+  random.seed(1982)
+  inds = rover_obs.index.values.copy()
+  random.shuffle(inds)
+  shuffled_rover = rover_obs.ix[inds]
+  actual = dgnss.single_difference(shuffled_rover, base_obs)
+  assert_frame_equal(actual, expected_diffs)
+
+  # drop a row from rover and make sure it's handled properly
+  subset_rover = shuffled_rover.iloc[1:]
+  actual = dgnss.single_difference(subset_rover, base_obs)
+  assert_frame_equal(actual, expected_diffs.ix[subset_rover.index].sort())
+
+  # drop a row from rover and make sure it's handled properly
+  subset_base = base_obs.iloc[1:]
+  actual = dgnss.single_difference(rover_obs, subset_base)
+  assert_frame_equal(actual, expected_diffs.ix[subset_base.index].sort())
+
+
+def test_make_propagated_single_differences(ephemerides):
+  """
+  Create single differences for pairs of rover and base stations
+  that correspond to different times of arrival, then confirm that the
+  resulting single differences agree with the geometric interpretation
+  of single differences.
+  """
+  # Compute the expected baseline from the base / rover reference locations
+  base_ecef = np.array(locations.LEICA_ABSOLUTE)
+  rover_ecef = np.array(locations.NOVATEL_ABSOLUTE)
+  expected_baseline = rover_ecef - base_ecef
+
+  # create a set of base observations
+  base_toa = ephemerides['toe'].values[0] + np.timedelta64(100, 's')
+  base_obs = synthetic.observations_from_toa(ephemerides,
+                                             base_ecef, base_toa)
+
+  omega_unit_vect = dgnss.omega_dot_unit_vector(base_ecef, base_obs,
+                                                expected_baseline)
+  # the single differences should equal the baseline dotted with the unit vectors
+  expected_sdiffs = np.dot(omega_unit_vect, expected_baseline)
+  # now compute the single difference between base and rover observations when
+  # the base observation needs to be propagated forward in time (up to 10
+  # seconds).
+  for i in range(10):
+    toa = base_toa + np.timedelta64(i, 's')
+    rover_obs = synthetic.observations_from_toa(ephemerides,
+                                                rover_ecef, toa)
+
+    sdiffs = dgnss.make_propagated_single_differences(rover_obs,
+                                                      base_obs,
+                                                      base_pos_ecef=base_ecef)
+    # TODO: Using datetime64 objects with nanosecond resolution means
+    # that we can only get +/- 0.3m accuracy on ranges!  Oops!  We'll need to
+    # change the way times are represented, perhaps rolling back to using
+    # wn, tow
+    np.testing.assert_allclose(sdiffs['pseudorange'].values,
+                               expected_sdiffs,
+                               atol=6e-1)
+
+
+def test_matches_make_measurements(synthetic_state):
+  """
+  Compute double differences and make sure they match the differences
+  from swiftnav.dgnss_management.make_measurements_
+  """
+  # make a set of single differences
+  base_obs = ephemeris.add_satellite_state(synthetic_state['base'],
+                                           account_for_sat_error=False)
+  rover_obs = ephemeris.add_satellite_state(synthetic_state['rover'],
+                                           account_for_sat_error=False)
+  base_ecef = synthetic_state['base'][['ref_x', 'ref_y', 'ref_z']].values[0]
+  sdiffs = dgnss.make_propagated_single_differences(rover_obs,
+                                                    base_obs,
+                                                    base_pos_ecef=base_ecef)
+  sdiffs_t = list(dgnss.create_single_difference_objects(sdiffs))
+  # pass them through swiftnav's code
+  expected_ddiffs = dgnss_management.make_measurements_(sdiffs_t)
+  # then similar python code
+  actual_ddiffs = dgnss.double_difference(sdiffs)
+  # and make sure the outputs agree.
+  nddiffs = len(sdiffs_t) - 1
+  np.testing.assert_array_equal(expected_ddiffs[:nddiffs],
+                                actual_ddiffs['carrier_phase'].values)
+  np.testing.assert_array_equal(expected_ddiffs[nddiffs:],
+                                actual_ddiffs['pseudorange'].values)
+
+
+def test_double_differences(ephemerides):
+  """
+  Compute double differences and make sure they align with the geometric
+  interpretation.
+  """
+  # Compute the expected baseline from the base / rover reference locations
+  base_ecef = np.array(locations.LEICA_ABSOLUTE)
+  rover_ecef = np.array(locations.NOVATEL_ABSOLUTE)
+  expected_baseline = rover_ecef - base_ecef
+
+  # create a set of base observations
+  toa = ephemerides['toe'].values[0] + np.timedelta64(100, 's')
+  base_obs = synthetic.observations_from_toa(ephemerides,
+                                             base_ecef, toa)
+  rover_obs = synthetic.observations_from_toa(ephemerides,
+                                              rover_ecef, toa)
+  omega_unit_vect = dgnss.omega_dot_unit_vector(base_ecef, base_obs,
+                                                expected_baseline)
+  # compute a matrix of unit vector differences between the reference
+  # satellite and all others, the result will have shape (k - 1, 3).
+  unit_diffs = omega_unit_vect[1:] - omega_unit_vect[0]
+  # the double differences should equal the baseline dotted with the difference
+  # in unit vectors
+  expected_ddiffs = np.dot(unit_diffs, expected_baseline)
+
+  sdiffs = dgnss.make_propagated_single_differences(rover_obs,
+                                                    base_obs,
+                                                    base_pos_ecef=base_ecef)
+  ddiffs = dgnss.double_difference(sdiffs)
+  # Because synthetic observations are made with time units that only have
+  # nanosecond resolution we can't get better than +/-0.3 m resolution
+  # on ranges, in turn these are only accurate to 6e-1.
+  np.testing.assert_allclose(ddiffs['pseudorange'].values,
+                             expected_ddiffs, atol=6e-1)
+  np.testing.assert_allclose(ddiffs['carrier_phase'].values * c.GPS_L1_LAMBDA,
+                             expected_ddiffs, atol=6e-1)

--- a/tests/test_ephemeris.py
+++ b/tests/test_ephemeris.py
@@ -1,8 +1,10 @@
 import pytest
+import logging
 import numpy as np
 import pandas as pd
 
 from swiftnav import time as gpstime
+from swiftnav import ephemeris as swiftnav_ephemeris
 
 import gnss_analysis.constants as c
 
@@ -40,8 +42,8 @@ def test_calc_sat_state(ephemerides):
     pos, vel, clock_error, clock_error_rate = expected
     # make sure positions agree within a mm
     assert np.all(np.abs(act[['sat_x', 'sat_y', 'sat_z']] - pos) < 1e-3)
-    # make sure velocities agree within a mm/second
-    assert np.all(np.abs(act[['sat_v_x', 'sat_v_y', 'sat_v_z']] - vel) < 1e-3)
+    # make sure velocities agree within a micrometer/second
+    assert np.all(np.abs(act[['sat_v_x', 'sat_v_y', 'sat_v_z']] - vel) < 1e-6)
     # make sure clock error agree within a femtosecond
     assert np.all(np.abs(clock_error - act['sat_clock_error']) < 1e-12)
     # make sure clock error rate agrees within a femtosecond / second

--- a/tests/test_propagate.py
+++ b/tests/test_propagate.py
@@ -27,7 +27,7 @@ def test_delta_tof_for_known_position(ephemerides):
   # propagate forward in time for i number of seconds and compare to
   # expected observations.
   for i in np.linspace(0, 10, 11):
-    second_toa = first_toa + np.timedelta64(np.int32(i), 's')
+    second_toa = first_toa + np.timedelta64(int(i), 's')
     expected = synthetic.observations_from_toa(ephemerides, location_ecef,
                                                second_toa)
     to_drop = [x for x in expected.columns if x.startswith('ref_')]

--- a/tests/test_propagate.py
+++ b/tests/test_propagate.py
@@ -1,0 +1,122 @@
+import pytest
+import numpy as np
+import pandas as pd
+
+from swiftnav import time as gpstime
+from swiftnav import observation, track, signal
+
+from gnss_analysis import (synthetic, locations, propagate,
+                           ephemeris, observations, dgnss,
+                           time_utils)
+
+
+def test_delta_tof_for_known_position(ephemerides):
+  """
+  A first order test which ensures that when a known range is
+  propagated to a future time, the resulted propagated range
+  matches the exepcted range at that time.
+  """
+  location_ecef = locations.NOVATEL_ABSOLUTE
+
+  first_toa = ephemerides['time'] + np.timedelta64(100, 's')
+  first = synthetic.observations_from_toa(ephemerides, location_ecef,
+                                          first_toa)
+  # we don't account for satellite error here because tot is in system time
+  first = ephemeris.add_satellite_state(first, account_for_sat_error=False)
+
+  # propagate forward in time for i number of seconds and compare to
+  # expected observations.
+  for i in np.linspace(0, 10, 11):
+    second_toa = first_toa + np.timedelta64(np.int32(i), 's')
+    expected = synthetic.observations_from_toa(ephemerides, location_ecef,
+                                               second_toa)
+    to_drop = [x for x in expected.columns if x.startswith('ref_')]
+    expected.drop(to_drop, axis=1, inplace=True)
+    expected = ephemeris.add_satellite_state(expected,
+                                             account_for_sat_error=False)
+
+    actual = propagate.delta_tof_propagate(location_ecef, first,
+                                            new_toa=second_toa)
+
+    # make sure the carrier phase is very nearly the same.
+    np.testing.assert_almost_equal(expected['carrier_phase'].values,
+                                   actual['carrier_phase'].values, 1)
+    # We don't expect the time of transmission to be perfect, but do
+    # expect it to be within a nanosec of the actual value, so we pop
+    # it from the data frame in order to use pandas equality compare utils
+    # later.
+    d_tot = expected.pop('tot') - actual.pop('tot')
+    assert np.all(np.abs(d_tot) <= np.timedelta64(1, 'ns'))
+
+    expected.pop('sat_time')
+    actual.pop('sat_time')
+    pd.util.testing.assert_frame_equal(expected, actual[expected.columns])
+
+
+@pytest.mark.skipif(True, reason="still sorting this one out.")
+def test_matches_make_propagated_sdiffs(ephemerides):
+
+  def make_nav_meas(obs):
+    lock_time = np.nan
+    # NOTE: this is using the time of transmission NOT the gpstime
+    tot = gpstime.GpsTime(**time_utils.datetime_to_tow(obs['time']))
+    sid = signal.GNSSSignal(sat=obs.name, band=0, constellation=0)
+    nm = track.NavigationMeasurement(raw_pseudorange=obs.raw_pseudorange,
+                                     pseudorange=obs.pseudorange,
+                                     carrier_phase=obs.carrier_phase,
+                                     raw_doppler=obs.get('doppler', np.nan),
+                                     doppler=obs.get('doppler', np.nan),
+                                     sat_pos=obs[['sat_x', 'sat_y', 'sat_z']],
+                                     sat_vel=obs[['sat_v_x', 'sat_v_y', 'sat_v_z']],
+                                     snr=obs.cn0,
+                                     lock_time=lock_time,
+                                     tot=tot,
+                                     sid=sid,
+                                     lock_counter=obs.lock)
+    return nm
+
+  toa = ephemerides['time'].values[0]
+  toa += np.timedelta64(np.int32(100), 's')
+  rover_obs = synthetic.observations_from_toa(ephemerides,
+                                             locations.NOVATEL_ABSOLUTE,
+                                             toa)
+  rover_obs = ephemeris.add_satellite_state(rover_obs,
+                                            ephemerides,
+                                            account_for_sat_error=True)
+
+  base_toa = toa - np.timedelta64(-np.int32(1), 's')
+  base_obs = synthetic.observations_from_toa(ephemerides,
+                                             locations.LEICA_ABSOLUTE,
+                                             base_toa)
+  base_obs = ephemeris.add_satellite_state(base_obs,
+                                           ephemerides,
+                                           account_for_sat_error=True)
+
+  rover_nm = [make_nav_meas(x) for _, x in rover_obs.iterrows()]
+  base_nm = [make_nav_meas(x) for _, x in base_obs.iterrows()]
+
+  base_pos = base_obs[['ref_x', 'ref_y', 'ref_z']].values[0]
+  remote_dists = np.linalg.norm(base_obs[['sat_x', 'sat_y', 'sat_z']] - base_pos,
+                                axis=1)
+
+  t = gpstime.GpsTime(**time_utils.datetime_to_tow(toa))
+  es = [observations.mk_ephemeris(x)
+        for _, x in ephemerides.reset_index().iterrows()]
+  sdiffs_t = observation.make_propagated_sdiffs_(rover_nm, base_nm,
+                                                 remote_dists, base_pos,
+                                                 es, t)
+
+  sdiffs = dgnss.make_propagated_single_differences(rover_obs, base_obs,
+                                                    locations.LEICA_ABSOLUTE)
+
+  libswiftnav_sdiffs = pd.DataFrame(x.to_dict() for x in sdiffs_t)
+  libswiftnav_sdiffs['sid'] = [x['sat'] for x in libswiftnav_sdiffs['sid']]
+  libswiftnav_sdiffs.set_index('sid', inplace=True)
+  comp_vars = ['carrier_phase', 'pseudorange']
+  import ipdb; ipdb.set_trace()
+  libswiftnav_sdiffs[comp_vars] == sdiffs[comp_vars]
+#   libswiftnav_sdiffs['sid'] = libswiftnav_sdiffs[]
+
+  for sd_t, sd in zip(sdiffs_t, sdiffs):
+
+    pass

--- a/tests/test_propagate.py
+++ b/tests/test_propagate.py
@@ -76,21 +76,15 @@ def test_matches_make_propagated_sdiffs(ephemerides):
     return nm
 
   toa = ephemerides['time'].values[0]
-  toa += np.timedelta64(np.int32(100), 's')
+  toa += np.timedelta64(100, 's')
   rover_obs = synthetic.observations_from_toa(ephemerides,
                                              locations.NOVATEL_ABSOLUTE,
                                              toa)
-  rover_obs = ephemeris.add_satellite_state(rover_obs,
-                                            ephemerides,
-                                            account_for_sat_error=True)
 
-  base_toa = toa - np.timedelta64(-np.int32(1), 's')
+  base_toa = toa - np.timedelta64(1, 's')
   base_obs = synthetic.observations_from_toa(ephemerides,
                                              locations.LEICA_ABSOLUTE,
                                              base_toa)
-  base_obs = ephemeris.add_satellite_state(base_obs,
-                                           ephemerides,
-                                           account_for_sat_error=True)
 
   rover_nm = [make_nav_meas(x) for _, x in rover_obs.iterrows()]
   base_nm = [make_nav_meas(x) for _, x in base_obs.iterrows()]
@@ -102,21 +96,18 @@ def test_matches_make_propagated_sdiffs(ephemerides):
   t = gpstime.GpsTime(**time_utils.datetime_to_tow(toa))
   es = [observations.mk_ephemeris(x)
         for _, x in ephemerides.reset_index().iterrows()]
-  sdiffs_t = observation.make_propagated_sdiffs_(rover_nm, base_nm,
-                                                 remote_dists, base_pos,
-                                                 es, t)
 
-  sdiffs = dgnss.make_propagated_single_differences(rover_obs, base_obs,
-                                                    locations.LEICA_ABSOLUTE)
+  # These libswiftnav_sdiffs are very different from the sdiffs computed in python
 
-  libswiftnav_sdiffs = pd.DataFrame(x.to_dict() for x in sdiffs_t)
-  libswiftnav_sdiffs['sid'] = [x['sat'] for x in libswiftnav_sdiffs['sid']]
-  libswiftnav_sdiffs.set_index('sid', inplace=True)
-  comp_vars = ['carrier_phase', 'pseudorange']
-  import ipdb; ipdb.set_trace()
-  libswiftnav_sdiffs[comp_vars] == sdiffs[comp_vars]
-#   libswiftnav_sdiffs['sid'] = libswiftnav_sdiffs[]
+  # TODO: The following requires a non-master build of libswiftnav
+#   sdiffs_t = observation.make_propagated_sdiffs_(rover_nm, base_nm,
+#                                                  remote_dists, base_pos,
+#                                                  es, t)
+#
+#   sdiffs = dgnss.make_propagated_single_differences(rover_obs, base_obs,
+#                                                     locations.LEICA_ABSOLUTE)
+#
+#   libswiftnav_sdiffs = pd.DataFrame(x.to_dict() for x in sdiffs_t)
+#   libswiftnav_sdiffs['sid'] = [x['sat'] for x in libswiftnav_sdiffs['sid']]
+#   libswiftnav_sdiffs.set_index('sid', inplace=True)
 
-  for sd_t, sd in zip(sdiffs_t, sdiffs):
-
-    pass

--- a/tests/test_rinex.py
+++ b/tests/test_rinex.py
@@ -128,6 +128,6 @@ def test_observation(rinex_observation):
   # and makes sure that value is parsed correctly.
   for i, obs in enumerate(rinex.iter_observations(f)):
     if np.any(obs['time'] == datetime.datetime(2016, 1, 15, 0, 0, 18)):
-      np.testing.assert_array_equal(obs.ix['G32', 'carrier_phase'].values,
-                                    np.array([125133856.682, 97506905.871]))
+      np.testing.assert_array_equal(obs.ix['G32', 'carrier_phase'],
+                                    np.array(125133856.682))
       break

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -38,7 +38,7 @@ def test_matches_piksi(jsonlog):
 
     py_pos = solution.single_point_position(state['rover'])
     piksi_pos = state['rover_spp_ecef'][['x', 'y', 'z']]
-    # right now 5cm agreement is all we can get (often less that a cm though).
+    # right now 5cm agreement is all we can get (often less than a cm though).
     # This is possibly due to rounding of the pseudoranges during message
     # transmission and the fact that observations are propagated using doppler,
     # but doppler is not sent in the messages.  Doppler can be inferred using


### PR DESCRIPTION
Contains functions for computing single and double differences, propagation algorithms and tests to confirm these match the geometrically derived expectations.

A few notes:

- Times are currently represented using np.datetime64 objects, but these only support nano second precision which introduces +/- 0.3 m errors in computed ranges and resulted in some loose equivalence checks in the tests.  We'll likely want to roll back to using `wn`, `tow` time representations or some equivalent.
- The propagation and differencing algorithms are internally tested and match geometric expectations, but do not match what comes out of libswiftnav.
- This change does not contain the simple float filter, that was cut out to keep the PR smaller and is included in a subsequent PR (akleeman/gnss-analysis/pull/6).

@swift-nav/estimation 