### PR TITLE
Simple Float Filter

### DIFF
--- a/gnss_analysis/filters/__init__.py
+++ b/gnss_analysis/filters/__init__.py
@@ -1,0 +1,3 @@
+from .common import TimeMatchingDGNSSFilter
+from gnss_analysis.filters.swiftnav_filter import SwiftNavDGNSSFilter
+from gnss_analysis.filters.kalman_filter import KalmanFilter

--- a/gnss_analysis/filters/common.py
+++ b/gnss_analysis/filters/common.py
@@ -96,9 +96,9 @@ class TimeMatchingDGNSSFilter(DGNSSFilter):
     self.rover_buffer = pd.DataFrame()
     self.prev_base = None
 
-  def updated_matched_obs(self, rover_obs, base_obs):
+  def update_matched_obs(self, rover_obs, base_obs):
     raise NotImplementedError("TimeMatchingDGNSSFilter requires implementing"
-                              " updated_matched_obs.")
+                              " update_matched_obs.")
 
   def _pop_from_buffer(self, t):
     """
@@ -193,4 +193,4 @@ class TimeMatchingDGNSSFilter(DGNSSFilter):
     # We now have a pair of rover and base observations that correspond
     # to the same time of arrival, we pass them on to the implementing
     # filter.
-    self.updated_matched_obs(rover_obs, base_obs)
+    self.update_matched_obs(rover_obs, base_obs)

--- a/gnss_analysis/filters/common.py
+++ b/gnss_analysis/filters/common.py
@@ -84,13 +84,10 @@ class TimeMatchingDGNSSFilter(DGNSSFilter):
   
   This is an abstract filter which takes care of the logic required
   to match base observations with corresponding rover observations.
-  Each time this filter is updated the rover observations are pushed
-  into a buffer and any base observations (if they exist) are matched
-  with the corresponding rover observations in the buffer.
   
-  This Filter does NOT propagate base observations to match the rover
-  observations, it is designed to be perform similar to piksi_firmware
-  with low latency mode OFF.
+  Each time this filter is updated the rover observations are pushed
+  into a buffer, then when a new base observation is encountered it
+  is matched with the corresponding rover observations from the buffer.
   """
 
   def __init__(self, *args, **kwdargs):

--- a/gnss_analysis/filters/common.py
+++ b/gnss_analysis/filters/common.py
@@ -1,0 +1,199 @@
+import logging
+import numpy as np
+import pandas as pd
+
+from gnss_analysis import dgnss, ephemeris, propagate, solution
+
+
+def get_unique_value(x):
+  uniq = np.unique(x)
+  assert uniq.size == 1
+  return uniq[0]
+
+
+class DGNSSFilter(object):
+  """
+  DGNSSFilter
+  
+  An abstract class that contains some core shared logic required for
+  a DGNSS filter used to estimate baselines.
+  """
+
+  def __init__(self, base_pos=None):
+    if base_pos is None:
+      self.base_known = False
+      self.base_pos = None
+    else:
+      self.base_known = True
+      self.base_pos = base_pos
+    self.prev_sdiffs = None
+
+  def maybe_update_base_position(self, base_obs):
+    """
+    If base_known is True this function does nothing, otherwise it
+    will update the base position by performing PVT solve.
+    """
+    if not self.base_known:
+      # TODO: on the piksi this position has a low pass filter applied.
+      self.base_pos = solution.single_point_position(base_obs)['pos_ecef']
+
+  def get_single_diffs(self, rover_obs, base_obs, propagate_base=False):
+    """
+    Computes the single differences between a set of rover and base observations.
+    """
+    rover_toa = get_unique_value(rover_obs['time'])
+    if propagate_base:
+      # Move the base observations forward in time to math the rover obs.
+      base_obs = propagate.delta_tof_propagate(self.base_pos,
+                                               base_obs,
+                                               rover_toa)
+    else:
+
+      # if we aren't propagating make sure they are on the same time.
+      assert get_unique_value(base_obs['time']) == rover_toa
+
+    # Compute single differences.
+    sdiffs = dgnss.make_propagated_single_differences(rover_obs, base_obs,
+                                                      self.base_pos)
+
+    if self.prev_sdiffs is not None:
+      # check to make sure the lock hasn't changed since the previous
+      # update.
+      locks = sdiffs['lock'].align(self.prev_sdiffs['lock'], 'left')
+      use = locks[0] == locks[1]
+      if not np.all(use):
+        logging.warn("Lock counters slipped, dropping %d diff(s)"
+                     % np.sum(np.logical_not(use)))
+      good_sdiffs = sdiffs[use]
+    else:
+      good_sdiffs = sdiffs
+    # store the current sdiffs for the next iteration
+    self.prev_sdiffs = good_sdiffs
+    return sdiffs
+
+  def update(self, state):
+    raise NotImplementedError
+
+  def get_baseline(self, state):
+    raise NotImplementedError
+
+
+class TimeMatchingDGNSSFilter(DGNSSFilter):
+  """
+  TimeMatchingDGNSSFilter
+  
+  This is an abstract filter which takes care of the logic required
+  to match base observations with corresponding rover observations.
+  Each time this filter is updated the rover observations are pushed
+  into a buffer and any base observations (if they exist) are matched
+  with the corresponding rover observations in the buffer.
+  
+  This Filter does NOT propagate base observations to match the rover
+  observations, it is designed to be perform similar to piksi_firmware
+  with low latency mode OFF.
+  """
+
+  def __init__(self, *args, **kwdargs):
+    super(TimeMatchingDGNSSFilter, self).__init__(*args, **kwdargs)
+    # TODO: this is certainly not the most efficient buffer
+    self.rover_buffer = pd.DataFrame()
+    self.prev_base = None
+
+  def updated_matched_obs(self, rover_obs, base_obs):
+    raise NotImplementedError("TimeMatchingDGNSSFilter requires implementing"
+                              " updated_matched_obs.")
+
+  def _pop_from_buffer(self, t):
+    """
+    Removes the rover observations matching tow from the buffer.  The buffer
+    is then reduced to contain only observations after the requested tow.
+    """
+    use = self.rover_buffer['time'] == t
+    # the buffer hasn't built up long enough of a history yet, return none
+    if not np.any(use):
+      return None
+    matched_obs = self.rover_buffer[use]
+    # we should no longer need any rover observations from at or before
+    # the currently requested tow
+    self.rover_buffer = self.rover_buffer[self.rover_buffer.time > t]
+    return matched_obs
+
+  def _append_to_buffer(self, rover_state):
+    """
+    Adds a set of rover state observations to the buffer.
+    """
+    rover_toa = get_unique_value(rover_state['time'])
+    # make sure the current tow doesn't exist in the buffer yet,
+    # tow needs to be unique since it's used to index.
+    assert (self.rover_buffer.empty or
+            not rover_toa in self.rover_buffer['time'])
+    # update the DataFrame buffer
+    self.rover_buffer = pd.concat([self.rover_buffer,
+                                   rover_state])
+
+  def _validate_base_observation(self, state):
+    # Check to see if we have a set of base observations.  Without
+    # them we can't proceed.
+    if state.get('base', None) is None:
+      logging.warn("No base observations found, not updating filter.")
+      return False
+
+    # get the time of arrival for the base observations
+    toa = get_unique_value(state['base']['time'])
+
+    # make sure the the current base observations are newer than
+    # anything we've seen before.  If not we skip this update.
+    if (self.prev_base is not None and
+        toa <= get_unique_value(self.prev_base['time'])):
+      logging.warn("Base observations are old, not updating filter.")
+      return False
+    return True
+
+  def update(self, state):
+    """
+    Updates the filter given the new state.
+    """
+    # Always push the rover state to the buffer
+    self._append_to_buffer(state['rover'])
+
+    # Make sure the state contains a new and valid base observation
+    if not self._validate_base_observation(state):
+      return
+
+    # Store the current base as a reference for the next iteration
+    self.prev_base = state['base']
+    # Possibly update the base position using it's SPP.
+    self.maybe_update_base_position(state['base'])
+
+    # Infer any required variables and add satellite state.
+    state['rover'] = ephemeris.add_satellite_state(state['rover'],
+                                                   state['ephemeris'],
+                                                   account_for_sat_error=True)
+
+    # get the time of arrival for the base observations
+    toa = get_unique_value(state['base']['time'])
+
+    # Attempt to find a rover observation that corresponds to the base
+    # observation.
+    rover_obs = self._pop_from_buffer(toa)
+    # If no observations were found, issue a warning and return
+    if rover_obs is None:
+      logging.warn("No rover observations available for %f" % toa)
+      return
+
+    # this should be checked before calling this function, make sure
+    assert not rover_obs.empty
+    assert not state['base'].empty
+    assert rover_obs.shape[0] >= 4
+    assert state['base'].shape[0] >= 4
+
+    # Add the satellite state information (position etc ..)
+    # to the rover observations.
+    base_obs = ephemeris.add_satellite_state(state['base'],
+                                             state['ephemeris'],
+                                             account_for_sat_error=True)
+
+    # We now have a pair of rover and base observations that correspond
+    # to the same time of arrival, we pass them on to the implementing
+    # filter.
+    self.updated_matched_obs(rover_obs, base_obs)

--- a/gnss_analysis/filters/kalman_filter.py
+++ b/gnss_analysis/filters/kalman_filter.py
@@ -90,8 +90,10 @@ class KalmanFilter(common.TimeMatchingDGNSSFilter):
     # to clock and hardware offsets.  As a result, we drop the first
     # row and take subsets of the transform matrix.
     P_bar = P[1:]
-    F = P_bar[:, 1:]
-
+    # As defined by Chang et al F is:
+    #   F = I - e e^T / (m - sqrt(m))
+    # Note that the size of e in equations 12 and 16 are different.
+    F = np.eye(m - 1) - np.ones((m - 1, m - 1)) / (m - np.sqrt(m))
     # We convert the pseudorange to wavelengths and scale by the
     # ratio of carrier phase to pseudorange noises, then apply
     # P_bar to get a new observation vector, y, which loosely corresponds to

--- a/gnss_analysis/filters/kalman_filter.py
+++ b/gnss_analysis/filters/kalman_filter.py
@@ -1,0 +1,285 @@
+
+import logging
+import numpy as np
+
+from gnss_analysis import dgnss
+from gnss_analysis import constants as c
+
+from gnss_analysis.filters import common
+
+
+class KalmanFilter(common.TimeMatchingDGNSSFilter):
+  """
+  This version of an Extended Kalman Fiter is based largely off the paper:
+  
+    Xiao-wen Chang and Christopher C. Paige and Lan Yin
+    Code and Carrier Phase Based Short Baseline GPS Positioning: Computational Aspects
+  
+  The largest obvious difference between this algorithm and a typical
+  float filter is the use of householder transformations in place of double
+  differences.
+  """
+
+  def __init__(self, *args, **kwdargs):
+    self.initialized = False
+    super(KalmanFilter, self).__init__(*args, **kwdargs)
+
+  def initialize_filter(self, rover_obs, base_obs):
+    self.prev_time = common.get_unique_value(rover_obs['time'])
+    self.sids = rover_obs.index.intersection(base_obs.index)
+    self.x = np.zeros(3 + self.sids.size - 1)
+    # This sets our first guess to be within ~1000 km of the base station
+    self.P = 5e5 * np.eye(self.x.size)
+    self.initialized = True
+
+  def update_filter(self,):
+    pass
+
+  def get_baseline(self, state):
+    if not self.initialized:
+      return None
+    else:
+      return self.x[:3]
+
+  def observation_model(self, rover_obs, base_obs):
+    """
+    Builds variables required for the observation model from a pair of rover
+    and base observations.
+    
+    Returns
+    -------
+    y : np.ndarray
+      A (transformed) array of single difference observations that loosely
+      corresponds to double differenced pseudoranges and carrier phases.
+    H : np.ndarray
+      A 2d array that corresponds to the observation model.  It is used
+      to compute the expected values of y given the current estimate of x.
+    R : np.ndarray
+      A 2d array that represents the covariance of noise in the observation
+      model.  In otherwords, it tells us how confident we are in the values
+      of y.
+    """
+    sdiffs = self.get_single_diffs(rover_obs, base_obs, propagate_base=False)
+
+    # This is from equation 1 in Chang, Paige Yin, it is essentially
+    # the unit vector pointing from the base receiver to each satellite
+    # scaled such that omega_e * baseline = single_difference.
+    # As they mention, it could be replaced by one but for high precision
+    # applications should be taken into account.
+    omega_e = dgnss.omega_dot_unit_vector(self.base_pos, base_obs,
+                                          self.x[:3])
+    # E_k = omega_e / lambda (see equation 8).
+    E = omega_e / c.GPS_L1_LAMBDA
+
+    # m is the number of satellites
+    m = sdiffs.shape[0]
+    # Here we build a house holder transformation P that allows us to
+    # remove shared errors (the same way double differencing does) but
+    # without introducing correlation.
+    u = -1. / np.sqrt(m) * np.ones(m)
+    u[0] += 1
+    P = np.eye(m) - 2 * np.outer(u, u) / np.inner(u, u)
+
+    # TODO: confirm these values for the measurement standard deviations!
+    sig_cp = 0.1
+    sig_pr = 10. / c.GPS_L1_LAMBDA
+    sig = sig_cp / sig_pr
+
+    # After applying P to the single differences we will still have m
+    # observations, but the first will contain unknown errors corresponding
+    # to clock and hardware offsets.  As a result, we drop the first
+    # row and take subsets of the transform matrix.
+    P_bar = P[1:]
+    F = P_bar[:, 1:]
+
+    # We convert the pseudorange to wavelengths and scale by the
+    # ratio of carrier phase to pseudorange noises, then apply
+    # P_bar to get a new observation vector, y, which loosely corresponds to
+    # double differenced observations with error covariance sig^2 * I.
+    pr_in_wavelengths = sdiffs['pseudorange'].values / c.GPS_L1_LAMBDA
+    y = np.concatenate([np.dot(P_bar, sdiffs['carrier_phase'].values),
+                        sig * np.dot(P_bar, pr_in_wavelengths)])
+
+    # Now we compute the linear operator that produces our
+    # observations y from the current state estimate x.
+    #   y = np.dot(H, x) + v ; v ~ N(0, sig_cp)
+    PE = np.dot(P_bar, E)
+    # H takes a block form [[PE, F], [sig * PE, 0]]
+    # the first column of H is simply the double differencing operators
+    # computed above.  The second column corresponds to coefficients
+    # for the integer abiguities.  Note that these are only applied
+    # to the carrier phase.
+    H = np.asarray(np.bmat([[PE, F], [sig * PE, np.zeros_like(F)]]))
+
+    # observation noise
+    R = sig_cp * np.eye(H.shape[0])
+
+    return y, H, R
+
+
+  def updated_matched_obs(self, rover_obs, base_obs):
+    if not self.initialized:
+      self.initialize_filter(rover_obs, base_obs)
+
+    logging.warn("Ignoring any rising/setting satellites")
+    base_obs = base_obs.ix[self.sids]
+    rover_obs = rover_obs.ix[self.sids]
+
+    n = self.x.size
+    # the observation vector, linear operator and observation noise
+    y, H, R = self.observation_model(rover_obs, base_obs)
+    # the process model.
+    F = np.eye(n)
+    # process noise
+    Q = np.eye(n)
+    # the first three values are the location, we don't expect
+    # the receiver will be moving more than 140 mph which over
+    # a tenth of a second time step comes out to a process
+    # noise with standard deviation of two.
+    Q[:3] *= 2.
+    # the rest are the ambiguities which should never change.  In
+    # fact, in future iterations of this model they should be
+    # removed from the filter altogether.
+    Q[3:] *= 0.001
+
+    x, P = kalman_predict(self.x, self.P, F, Q)
+    x, P = kalman_update(x, P, y, H, R)
+
+    self.x = x
+    self.P = P
+
+
+def expand_operator(z):
+  """
+  The definition of operators used in Linear Kalman Filters (LKFs)
+  and Extended Kalman filters (EKFs) are different, but the math is
+  largely the same.  This function takes operators that would be used
+  in a LKF (ie, a single matrix) and converts it into a function and
+   it's jacobian (which is required for EKFs).
+   
+  Parameters
+  ----------
+  z : np.ndarray or (function, np.ndarray)
+    An operator which can either be a single matrix (in the case
+    of a LKF) or function / jacobian tuple (in the case of an
+    EKF).
+  
+  Returns
+  ---------
+  f : callable
+    A function that applies the operator
+  J : np.array
+    The Jacobian of the function in the vicinity of the current state.
+  """
+  if isinstance(z, np.ndarray):
+    # if the operator is a matrix we assume it is a linear
+    # operator and return a function that simply applies the
+    # dot product and the linear operator as Jacobian.
+    return lambda x: np.dot(z, x), z
+  # Otherwise perhaps the operator is already a function
+  # jacobian tuple?
+  try:
+    f, J = z
+  except ValueError:
+    raise ValueError("Can't interpret z as a filter operator")
+  # TODO: eventually we can pass in theano functions and directly
+  # compute the jacobian of an arbitrary function in here.
+  return f, J
+
+
+def kalman_predict(x, P, F, Q, B=None, u=None):
+  """
+  Takes a pair of state and covariance arrays (x, P) corresponding
+  to the state at some iteration of a kalman filter, and advances
+  the state to the next time step using the transition F, process
+  noise Q and optional forcings B *u.
+    
+  Parameters
+  ----------
+  x : np.ndarray
+    A 1-d array representing the mean of the state estimate at
+    some iteration, k-1, of a kalman filter.
+  P : np.ndarray
+    A 2-d array representing the covariance of the state estimate at
+    some iteration, k-1, of a kalman filter.
+  F : operator (see expand_operator)
+    The state transition model.
+  Q : np.ndarray
+    A 2-d array representing the noise introduced in the process
+    model during one time step.
+  B : np.ndarray
+    A 2-d array that projects the describes the impact on forcings
+    (u) on the state (x)
+  u : np.ndarray
+    A 1-d array that holds forcings, aka control variables.
+    
+  Returns
+  ---------
+  x : np.ndarray
+    A 1-d array representing the mean of the a priori state estimate at
+    some iteration, k, of a kalman filter.  This is the best estimate
+    of x_k given x_{k-1} but without accounting for observations at step k.
+  P : np.ndarray
+    A 2-d array representing the covariance of the a priori state estimate at
+    some iteration, k, of a kalman filter. This is the best estimate
+    of P_k given x_{k-1} but without accounting for observations at step k.
+  """
+  # F should be convertable to an operator pair (function, jacobian) that
+  # applies the transition process model, ie x_k = f(x_{k-1}).
+  f, F = expand_operator(F)
+  # apply the state transition function f
+  x = f(x)
+  # optionally apply and forcings
+  if B is not None and u is not None:
+    x += np.dot(B, u)
+  # update the covariance of x, this comes in two parts
+  # F P F^T, which is the covariance of x_k due to the
+  # transition function, and Q which is the noise
+  # of the process model.
+  P = np.dot(np.dot(F, P), F.T) + Q
+  return x, P
+
+
+def kalman_update(x, P, y, H, R):
+  """
+  Takes a pair of state and covariance arrays (x, P) corresponding
+  to the state at some iteration of a kalman filter, and computes
+  and update to the state conditional on a new set of observations
+  y.
+  
+  Parameters
+  ----------
+  x : np.ndarray
+    A 1-d array representing the mean of the state estimate at
+    some iteration, k-1, of a kalman filter.
+  P : np.ndarray
+    A 2-d array representing the covariance of the state estimate at
+    some iteration, k-1, of a kalman filter.
+  y : np.ndarray
+    A 1-d array representing a set of new observations.
+  H : operator (see expand_operator)
+    The observation model. x' = H(y) + R
+  R : np.ndarray
+    A 2-d array representing the noise introduced in the measurement process
+    
+  Returns
+  ---------
+  x : np.ndarray
+    A 1-d array representing the mean of the posterior state estimate at
+    some iteration, k, of a kalman filter.  This is the best estimate
+    of x_k given x_{k-1} and all observations up to step k.
+  P : np.ndarray
+    A 2-d array representing the covariance of the posterior state estimate at
+    some iteration, k, of a kalman filter. This is the best estimate
+    of P_k given x_{k-1} and all observations up to step k.
+  """
+  h, H = expand_operator(H)
+  # actual observation minus the observation model
+  innov = y - h(x)
+  S = np.dot(np.dot(H, P), H.T) + R
+  # NOTE: np.linalg.inv(S) is a horrible HORRIBLE thing to do, but
+  #   for the first time around it should be fine.
+  K = np.dot(np.dot(P, H.T), np.linalg.inv(S))
+  x = x + np.dot(K, innov)
+  P = np.dot(np.eye(P.shape[0]) - np.dot(K, H), P)
+  return x, P

--- a/gnss_analysis/filters/swiftnav_filter.py
+++ b/gnss_analysis/filters/swiftnav_filter.py
@@ -1,0 +1,84 @@
+"""
+swiftnav_filter.py
+
+This Filter is designed with the intent of reproducing the same estimates
+that would have been made on the chip.  It uses as much logic from libswiftnav
+as possible.
+"""
+import logging
+import numpy as np
+
+from swiftnav import dgnss_management
+
+from gnss_analysis import dgnss, ephemeris
+from gnss_analysis.filters.common import TimeMatchingDGNSSFilter
+
+
+class SwiftNavDGNSSFilter(TimeMatchingDGNSSFilter):
+  """
+  This version of the filter simply uses the wrapped libswiftnav code,
+  essentially reproducing what is happening directly on the chip.
+  """
+  def __init__(self, disable_raim=False, *args, **kwdargs):
+    super(SwiftNavDGNSSFilter, self).__init__(*args, **kwdargs)
+    self.disable_raim = disable_raim
+    # our initial guess for the rover position is to assume it's simply
+    # in the same location as the base receiver.
+    self.rover_pos = np.zeros(3)
+    # Initialized the ambiguity state
+    self.amb_state = dgnss_management.AmbiguityState()
+
+  def updated_matched_obs(self, rover_obs, base_obs):
+    """
+    Updates the swiftnav kalman filter with a new pair of rover and base
+    station observations.
+    
+    TimeMatchingDGNSSFilter.update takes care of finding pairs of time
+    of arrival aligned rover and base observations, this function
+    is then responsible for actually updating the filter.
+    
+    See also: piksi_firmware/solution.c:process_matched_obs
+    """
+    # creates a DataFrame of single differences
+    rover_obs = rover_obs.copy()
+    base_obs = base_obs.copy()
+    rover_obs['carrier_phase'] = -rover_obs['carrier_phase']
+    base_obs['carrier_phase'] = -base_obs['carrier_phase']
+    sdiffs = self.get_single_diffs(rover_obs, base_obs, propagate_base=False)
+    # converts the DataFrame to c objects
+    sdiff_t = list(dgnss.create_single_difference_objects(sdiffs))
+    # update the filter
+    dgnss_management.dgnss_update_(sdiff_t, self.base_pos,
+                                   disable_raim=self.disable_raim)
+    # update the ambiguities
+    dgnss_management.dgnss_update_ambiguity_state_(self.amb_state)
+
+  def get_baseline(self, state):
+    """
+    Uses the current filter state to estimate the baseline for
+    a set of (possibly non-aligned) rover and base observations.
+    
+    Base observations are propagated to the rover time of arrival
+    (if required) before being used to compute the baseline.
+    """
+    # Add the satellite state information (position etc ..)
+    # to the rover observations.
+    state['base'] = ephemeris.add_satellite_state(state['base'],
+                                                  state['ephemeris'])
+    # creates a DataFrame of single differences
+    sdiffs = self.get_single_diffs(state['rover'], state['base'],
+                                   propagate_base=True)
+    # converts the DataFrame to c objects
+    sdiff_t = list(dgnss.create_single_difference_objects(sdiffs))
+    # use the current filter state to estimate the baseline
+    flag, n_used, baseline = dgnss_management.dgnss_baseline_(sdiff_t,
+                                                  self.base_pos,
+                                                  self.amb_state,
+                                                  disable_raim=self.disable_raim)
+    # check the flag to see if baseline computations succeeded.  If not
+    # we return None instead of a possibly bogus baseline.
+    if flag < 0:
+      logging.warn("Baseline computation failed with %d" % flag)
+      return None
+
+    return baseline

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,7 @@ def synthetic_state(ephemerides):
                                    tot)
 
 @pytest.fixture()
-def synthetic_stationary_state_sequence(ephemerides):
+def synthetic_stationary_states(ephemerides):
   """
   Returns an iterator over synthetic states for which the rover and
   base station are stationary.
@@ -102,13 +102,15 @@ def synthetic_stationary_state_sequence(ephemerides):
     base_ecef = locations.LEICA_ABSOLUTE
 
     for dt in time_steps:
-      toa = ephemerides['time'] + np.timedelta64(100 + dt, 's')
+      toa = np.max(ephemerides['toe'].values) + np.timedelta64(100 + int(1e3 * dt), 'ms')
       state = synthetic.synthetic_state(ephemerides, rover_ecef,
                                         base_ecef, toa)
       state['base'] = ephemeris.add_satellite_state(state['base'],
-                                                    state['ephemeris'])
+                                                    state['ephemeris'],
+                                                    account_for_sat_error=False)
       state['rover'] = ephemeris.add_satellite_state(state['rover'],
-                                                     state['ephemeris'])
-      yield state
+                                                     state['ephemeris'],
+                                                     account_for_sat_error=False)
+      yield state.copy()
 
   return iter_states(np.linspace(0., 100., 1001.))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,108 @@
+import pytest
+import numpy as np
+
+from gnss_analysis import locations, filters, solution, simulate
+
+
+@pytest.fixture()
+def dgnss_filter():
+  return filters.KalmanFilter(base_pos=locations.LEICA_ABSOLUTE)
+  # TODO: Eventually use py.test to iterate over all filters
+#   return filters.SwiftNavDGNSSFilter(disable_raim=True,
+#                                      base_pos=locations.LEICA_ABSOLUTE)
+
+@pytest.mark.slow
+def test_doesnt_diverge(synthetic_stationary_states, dgnss_filter):
+
+  # Here we iterate over some number of baseline solutions and
+  # report the error relative to the known baseline
+  def iter_errors():
+    for _, state in zip(range(100), synthetic_stationary_states):
+      base_ecef = state['base'][['ref_x', 'ref_y', 'ref_z']].values[0]
+      rover_ecef = state['rover'][['ref_x', 'ref_y', 'ref_z']].values[0]
+      expected_baseline = rover_ecef - base_ecef
+
+      # update the filter and compute the baseline
+      dgnss_filter.update(state)
+      bl = dgnss_filter.get_baseline(state)
+      yield bl - expected_baseline
+
+  # Then we solve for the slope of the error magnitude and make
+  # sure it isn't obviously blowing up.
+  errors = np.array([np.linalg.norm(x) for x in iter_errors()])
+  A = np.vstack([np.ones(errors.size), np.arange(errors.size)]).T
+  slope = np.linalg.lstsq(A, errors)[0][1]
+  # make sure the errors aren't increasing by more than a centimeter a sec
+  assert slope <= 0.01
+
+
+@pytest.mark.slow
+def test_eventually_gets_baseline(synthetic_stationary_states, dgnss_filter):
+
+  def assert_matches_at_some_point():
+    for i, state in enumerate(synthetic_stationary_states):
+      base_ecef = state['base'][['ref_x', 'ref_y', 'ref_z']].values[0]
+      rover_ecef = state['rover'][['ref_x', 'ref_y', 'ref_z']].values[0]
+      expected_baseline = rover_ecef - base_ecef
+
+      # update the filter and compute the baseline
+      dgnss_filter.update(state)
+      bl = dgnss_filter.get_baseline(state)
+      if not bl is None and i > 1:
+        # check to see if the estimated baseline is close to the expected one
+        # if it is close we break out of the for loop and consider the test
+        # a success, if not we ignore the assertion and continue
+        try:
+          np.testing.assert_allclose(bl, expected_baseline, atol=0.1)
+          return
+        except:
+          pass
+    # if the baseline matched at some point it would hit the return
+    # statement above and break out of this function.  If that didn't happen
+    # then we raise an assertion error
+    raise AssertionError("filter didn't match baseline before end of sequence")
+
+  assert_matches_at_some_point()
+
+
+@pytest.mark.skipif(True, reason="The swiftnav baseline quickly diverges.")
+def test_matches_libswiftnav(synthetic_stationary_states, dgnss_filter):
+
+  swift_filter = filters.SwiftNavDGNSSFilter(disable_raim=True,
+                                             base_pos=locations.LEICA_ABSOLUTE)
+
+  for _, state in zip(range(10), synthetic_stationary_states):
+    # This test fails because this baseline rapidly diverges.  It'll pass
+    # for the first iteration, but then error out
+    swift_filter.update(state)
+    swift_bl = swift_filter.get_baseline(state)
+
+    # update the filter and compute the baseline
+    dgnss_filter.update(state)
+    bl = dgnss_filter.get_baseline(state)
+
+    # for now we'll behappy if the tow agree within a meter.
+    np.testing.assert_allclose(bl, swift_bl, atol=1)
+
+
+
+@pytest.mark.skipif(True, reason="Can't match the piksi yet!")
+def test_matches_piksi_logs(jsonlog, dgnss_filter):
+
+  for state in solution.solution(simulate.simulate_from_log(jsonlog),
+                                 dgnss_filter):
+    # check that the single point positions match.
+    np.testing.assert_allclose(state['rover_spp_ecef'][['x', 'y', 'z']].values[0],
+                               state['rover_pos']['pos_ecef'],
+                               atol=0.001)
+    # if the python solver returned a non none baseline and
+    # the piksi logged an rtk solution we check to see if the
+    # two agree.
+    if (state['rover_pos'].get('baseline', None) is not None and
+        'rover_rtk_ned' in state):
+      baseline = state['rover_pos']['baseline']
+      piksi_baseline = state['rover_rtk_ned'][['n', 'e', 'd']]
+
+      print "piksi", piksi_baseline.values
+      print "python", baseline
+      print "actual", locations.NOVATEL_BASELINE

--- a/tests/test_kalman_filter.py
+++ b/tests/test_kalman_filter.py
@@ -1,0 +1,153 @@
+
+import py.test
+import numpy as np
+
+from gnss_analysis.filters import kalman_filter
+
+
+def test_kalman_predict_ekf():
+  """
+  Creates a linear kalman filter the equivalent extended kalman
+  filter and ensures that using the two different operator formats
+  results in the same output from kalman_predict.
+  """
+  n = 10
+  x = np.random.normal(size=n)
+  np.random.seed(1982)
+  F = np.random.permutation(np.eye(n))
+
+  def f(z):
+    return np.dot(F, z)
+
+  P = np.random.normal(size=(n, n))
+  P = np.dot(P, P.T)
+  Q = np.random.normal(size=(n, n))
+  Q = np.dot(Q, Q.T)
+
+  x_ekf, P_ekf = kalman_filter.kalman_predict(x, P, (f, F), Q)
+  x_lkf, P_lkf = kalman_filter.kalman_predict(x, P, F, Q)
+
+  np.testing.assert_array_equal(x_ekf, x_lkf)
+  np.testing.assert_array_equal(P_ekf, P_lkf)
+
+
+def test_kalman_predict():
+  # the size of x
+  n = 10
+  # the size of u
+  m = 3
+
+  x = np.zeros(n)
+  P = np.eye(n)
+  F = np.eye(n)
+  Q = np.zeros(n)
+  B = np.zeros((n, m))
+  u = np.zeros(m)
+  # In this situation we expect x and P to remain unchanged
+  x_new, P_new = kalman_filter.kalman_predict(x, P, F, Q, B, u)
+  np.testing.assert_array_equal(x_new, x)
+  np.testing.assert_array_equal(P_new, P)
+
+  # Now we add some process noise, so x should remain unchanged
+  # but the covariance P should increase.  Also make sure B and
+  # u default to None
+  Q = np.eye(n)
+  x_new, P_new = kalman_filter.kalman_predict(x, P, F, Q)
+  np.testing.assert_array_equal(x_new, x)
+  eigs = np.linalg.eigvals(P)
+  new_eigs = np.linalg.eigvals(P_new)
+  assert np.all(new_eigs > eigs)
+
+  # Now use a non-trivial transformation matrix, F.
+  np.random.seed(1982)
+  x = np.random.normal(size=n)
+  F = np.random.permutation(F)
+  np.testing.assert_allclose(np.abs(np.linalg.eigvals(F)), np.ones(n))
+  # x_new should be the state transformation applied to x
+  x_new, P_new = kalman_filter.kalman_predict(x, P, F, Q, B, u)
+  np.testing.assert_array_equal(x_new, np.dot(F, x))
+  # P should still increase
+  eigs = np.sort(np.linalg.eigvals(P))
+  new_eigs = np.sort(np.linalg.eigvals(P_new))
+  assert np.all(new_eigs > eigs)
+
+  # Try with some random non-trival covariance matrices
+  P = np.random.normal(size=(n, n))
+  P = np.dot(P, P.T)
+  Q = np.random.normal(size=(n, n))
+  Q = np.dot(Q, Q.T)
+  x_new, P_new = kalman_filter.kalman_predict(x, P, F, Q, B, u)
+  eigs = np.sort(np.linalg.eigvals(P))
+  new_eigs = np.sort(np.linalg.eigvals(P_new))
+  # the covariance of P should increase (though we permuted so need to sort)
+  assert np.all(new_eigs > eigs)
+  np.testing.assert_array_equal(x_new, np.dot(F, x))
+
+
+def test_kalman_update_ekf():
+  """
+  Creates a linear kalman filter the equivalent extended kalman
+  filter and ensures that using the two different operator formats
+  results in the same output from kalman_update.
+  """
+  # the size of x
+  n = 10
+  # the size of y
+  m = 3
+  x = np.random.normal(size=n)
+  np.random.seed(1982)
+  F = np.random.permutation(np.eye(n))
+
+  def f(z):
+    return np.dot(F, z)
+
+  P = np.random.normal(size=(n, n))
+  P = np.dot(P, P.T)
+  R = np.random.normal(size=(m, m))
+  R = np.dot(R, R.T)
+
+  H = np.random.normal(size=(m, n))
+  y = np.random.normal(size=m)
+  def h(z):
+    return np.dot(H, z)
+
+  x_ekf, P_ekf = kalman_filter.kalman_update(x, P, y, (h, H), R)
+  x_lkf, P_lkf = kalman_filter.kalman_update(x, P, y, H, R)
+
+  np.testing.assert_array_equal(x_ekf, x_lkf)
+  np.testing.assert_array_equal(P_ekf, P_lkf)
+
+
+def test_kalman_update():
+  # the size of x
+  n = 10
+  # the size of y
+  m = 3
+
+  x = np.zeros(n)
+  P = np.eye(n)
+  H = np.random.normal(size=(m, n))
+  R = np.eye(m)
+  # this will make innovations zero
+  y = np.dot(H, x)
+
+  # In this situation we expect x to remain unchanged
+  x_new, P_new = kalman_filter.kalman_update(x, P, y, H, R)
+  np.testing.assert_array_equal(x_new, x)
+  # the posterior distribution should have less noise than
+  # the prior.
+  eigs = np.linalg.eigvals(P)
+  new_eigs = np.linalg.eigvals(P_new)
+  # we have to add a fudge factor here due to numerical roundoff
+  assert np.all(np.sort(new_eigs) - np.sort(eigs) <= 1e-15)
+
+  # If there is large measurement noise, there should be less
+  # of a decrease in the posterior.
+  R = 2 * R
+  x_new, P_new = kalman_filter.kalman_update(x, P, y, H, R)
+  np.testing.assert_array_equal(x_new, x)
+  # the posterior distribution should have less noise than
+  # the prior.
+  larger_eigs = np.linalg.eigvals(P_new)
+  # we have to add a fudge factor here due to numerical roundoff
+  assert np.all(np.sort(new_eigs) - np.sort(larger_eigs) <= 1e-15)


### PR DESCRIPTION
Adds a filtering framework that was intended to mimic what happens on the piksi.  Namely, an abstract filter (`filters.TimeMatchingDGNSSFilter`) was added which handles the temporal alignment of base and rover observations.

Also includes a simple single frequency float filter based off:

> Xiao-wen Chang and Christopher C. Paige and Lan Yin
> [Code and Carrier Phase Based Short Baseline GPS Positioning: Computational Aspects](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.67.8051)

@swift-nav/estimation 