### PR TITLE
Added/Dropped Satellite logic in Simple Float Filter.

### DIFF
--- a/gnss_analysis/dgnss.py
+++ b/gnss_analysis/dgnss.py
@@ -46,6 +46,9 @@ def single_difference(rover, base):
   Computes the single difference between a pair of observations,
   one from a rover and one from a base station (though really
   they can be any two observation sets).
+  
+  The resulting data frame will be a copy of the base data frame
+  where any differenced values have been overwritten.
   """
   assert rover.index.name == 'sid'
   assert base.index.name == 'sid'
@@ -64,8 +67,10 @@ def single_difference(rover, base):
   # keep track of both the locks simultaneously
   if 'lock' in rover:
     sdiffs['lock'] = (rover['lock'] + base['lock'])
-  # return a copy of rover, but with single differnces instead of obs.
-  out = rover.copy()
+  # return a copy of base, but with single differnces instead of obs.
+  # the reason we return the base instead of the rover is that we often
+  # want to know the location of satellite .
+  out = base.copy()
   out.update(sdiffs)
   return out
 

--- a/gnss_analysis/filters/common.py
+++ b/gnss_analysis/filters/common.py
@@ -60,7 +60,11 @@ class DGNSSFilter(object):
       # check to make sure the lock hasn't changed since the previous
       # update.
       locks = sdiffs['lock'].align(self.prev_sdiffs['lock'], 'left')
-      use = locks[0] == locks[1]
+      # we still use a single difference if the previous was nan
+      # under the assumption that the filter logic will add it
+      # to the state appropriately
+      use = np.logical_or(locks[0] == locks[1],
+                          np.isnan(locks[1]))
       if not np.all(use):
         logging.warn("Lock counters slipped, dropping %d diff(s)"
                      % np.sum(np.logical_not(use)))
@@ -69,7 +73,7 @@ class DGNSSFilter(object):
       good_sdiffs = sdiffs
     # store the current sdiffs for the next iteration
     self.prev_sdiffs = good_sdiffs
-    return sdiffs
+    return good_sdiffs
 
   def update(self, state):
     raise NotImplementedError

--- a/gnss_analysis/filters/kalman_filter.py
+++ b/gnss_analysis/filters/kalman_filter.py
@@ -21,7 +21,8 @@ class KalmanFilter(common.TimeMatchingDGNSSFilter):
   differences.
   """
 
-  def __init__(self, sig_x=2., sig_z=0.01, sig_cp=0.02, sig_pr=3.,
+  def __init__(self, sig_x=2., sig_z=0.01, sig_cp=0.02,
+               sig_pr=3., sig_init=5e5,
                *args, **kwdargs):
     """
     Creates an instance of a KalmanFilter with the option of
@@ -44,8 +45,8 @@ class KalmanFilter(common.TimeMatchingDGNSSFilter):
     self.sig_z = sig_z
     self.sig_cp = sig_cp
     self.sig_pr = sig_pr
-    # This sets our first guess to be within ~1000 km of the base station
-    self.sig_init = 5e5
+    # The defualt sets our first guess to be within ~1000 km of the base
+    self.sig_init = sig_init
     self.initialized = False
     super(KalmanFilter, self).__init__(*args, **kwdargs)
 
@@ -58,7 +59,7 @@ class KalmanFilter(common.TimeMatchingDGNSSFilter):
     assert not self.initialized
     self.active_sids = rover_obs.index.intersection(base_obs.index)
     # A series containing the n, e and d components of the baseline (in meters)
-    pos = pd.Series(np.zeros(3), index=['n', 'e', 'd'])
+    pos = pd.Series(np.zeros(3), index=['x', 'y', 'z'])
     # sets the reference satellite to be the first in the active set and
     # creates the state vector of double differenced ambiguities.
     amb = pd.Series(np.zeros(self.active_sids.size - 1),


### PR DESCRIPTION
Added simple add/drop satellite logic which works as follows:

If a satellite was available at epoch **k-1** but not epoch **k** the satellite is treated as being dropped.  Dropped satellites are removed from the filter state vector and the corresponding row and col of the covariance are deleted.  If a dropped satellite was the reference satellite the filter reference satellite is swapped for a new one, then a standard drop is performed.

If a satellite was not available at epoch **k-1** but is at epoch **k** a zero is appended to the filter state vector and a new row and column with large diagonal element is added to the covariance.

@swift-nav/estimation 