### PR TITLE
Read/Write observation sets to HDF5.

### DIFF
--- a/gnss_analysis/filters/__init__.py
+++ b/gnss_analysis/filters/__init__.py
@@ -1,3 +1,4 @@
 from .common import TimeMatchingDGNSSFilter
 from gnss_analysis.filters.swiftnav_filter import SwiftNavDGNSSFilter
-from gnss_analysis.filters.kalman_filter import KalmanFilter
+from gnss_analysis.filters.kalman_filter import DynamicKalmanFilter
+from gnss_analysis.filters.kalman_filter import StaticKalmanFilter

--- a/gnss_analysis/filters/common.py
+++ b/gnss_analysis/filters/common.py
@@ -39,7 +39,8 @@ class DGNSSFilter(object):
     """
     if not self.base_known:
       # TODO: on the piksi this position has a low pass filter applied.
-      self.base_pos = solution.single_point_position(base_obs)['pos_ecef']
+      spp = solution.single_point_position(base_obs)
+      self.base_pos = spp[['x', 'y', 'z']].values
 
   def get_single_diffs(self, rover_obs, base_obs, propagate_base=False):
     """
@@ -183,8 +184,8 @@ class TimeMatchingDGNSSFilter(DGNSSFilter):
     rover_obs = self._pop_from_buffer(toa)
     # If no observations were found, issue a warning and return
     if rover_obs is None:
-      logging.warn("No rover observations available for %f" % toa)
-      return
+      logging.warn("No rover observations available for %s" % toa)
+      return False
 
     # this should be checked before calling this function, make sure
     assert not rover_obs.empty
@@ -202,3 +203,4 @@ class TimeMatchingDGNSSFilter(DGNSSFilter):
     # to the same time of arrival, we pass them on to the implementing
     # filter.
     self.update_matched_obs(rover_obs, base_obs)
+    return True

--- a/gnss_analysis/filters/kalman_filter.py
+++ b/gnss_analysis/filters/kalman_filter.py
@@ -44,12 +44,10 @@ class KalmanFilter(common.TimeMatchingDGNSSFilter):
     Returns the baseline corresponding to the current state.
     """
     # TODO: In theory we could return the baseline for future / past epochs
-
-    # For now we make just return the current filter state.
-    assert self.cur_time == common.get_unique_value(obs_set['rover']['time'])
     if not self.initialized:
       return None
     else:
+      # For now we make just return the current filter state.
       return self.x.iloc[:self.n_dim]
 
   def choose_reference_sat(self, new_sids):
@@ -471,10 +469,10 @@ class DynamicKalmanFilter(KalmanFilter):
     self.sig_init_a = sig_init_a
     # Time between measurements (will need to determine this on the fly later)
     self.dt = 1.0
-    self.gamma = np.exp(-self.dt / correlation_time) # See eqn 7.6.2 in Leick
+    self.gamma = np.exp(-self.dt / correlation_time)# See eqn 7.6.2 in Leick
     self.initialized = False
     # Number of dimensions we want to find a solution (x, y, z)
-    self.n_dim  = 3
+    self.n_dim = 3
     # Number of dynamic states (position, velocity, accleration)
     self.dynamic_states = 3
     # Index at which the ambiguity states start
@@ -501,8 +499,8 @@ class DynamicKalmanFilter(KalmanFilter):
     self.P = np.eye(self.x.size)
     # initialize the position covariance
     self.P[:self.n_dim] *= self.sig_init_p
-    self.P[self.n_dim :(2*self.n_dim)] *= self.sig_init_v
-    self.P[(2*self.n_dim):(3*self.n_dim)] *= self.sig_init_a
+    self.P[self.n_dim:(2 * self.n_dim)] *= self.sig_init_v
+    self.P[(2 * self.n_dim):(3 * self.n_dim)] *= self.sig_init_a
     # and the ambiguity covariance.
     self.P[self.ambiguity_states_idx:] *= self.sig_init_p / c.GPS_L1_LAMBDA
 

--- a/gnss_analysis/io/common.py
+++ b/gnss_analysis/io/common.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+from gnss_analysis import time_utils
+
+
+def tdcp_doppler(old, new):
+  """
+  Compute the doppler by using the time difference of the
+  carrier phase (TDCP).
+
+  Parameters:
+  -----------
+  old : pd.DataFrame
+    A DataFrame holding a previous set of carrier phase
+    observations along with corresponding tow
+  new : pd.DataFrame
+    A DataFrame holding new carrier phase observations
+    along with corresponding tow
+
+  Returns:
+  --------
+  doppler : pd.Series
+    A Series holding the doppler estimates.
+
+  See also: libswiftnav/src/track.c:tdcp_doppler
+  """
+  # TODO: make sure week numbers are the same since we don't
+  #  take them into account yet.  That will require doing some
+  #  NaN comparisons as well.
+
+  # TODO: This function does not handle receiver clock error,
+  #  in particular receiver clock drift (since we're differencing).
+  #  In order to fully handle such error we would need to know
+  #  if the observations have been propagated to 'time' yet.
+
+  # delta time in seconds
+  dt = time_utils.seconds_from_timedelta(new['time'] - old['time'])
+  # make sure dt is positive.
+  assert not np.any(dt.values <= 0.)
+  # compute the rate of change of the carrier phase
+  doppler = (new.carrier_phase - old.carrier_phase) / dt
+  # mark any computations with differing locks as nan
+  invalid = np.mod(new['lock'], 2) == 1
+  doppler[invalid] = np.nan
+  return doppler

--- a/gnss_analysis/io/hdf5.py
+++ b/gnss_analysis/io/hdf5.py
@@ -1,0 +1,103 @@
+import logging
+import numpy as np
+import pandas as pd
+
+
+def to_hdf5(obs_sets, output_path, strict=True,
+            **kwdargs):
+  """
+  Takes an iterator over observation sets and serializes them to
+  an HDF5 file.
+  
+  Parameters
+  ----------
+  obs_sets : iterable of observations sets (see simulate.py)
+    Takes an iterator over observation sets.  These observation
+    sets are expected to contain a rover field and otherwise
+    can contain any number of fields as long as they map to
+    pandas data frames with a defined index.  Corresponding
+    info dictionaries are serialized to the HDF5 file attributes.
+  output_path: string
+    The path to the location where the HDF5 file is written
+  **kwdargs
+    Any additional keyword arguments are passed on to
+    pd.HDF5Store() allowing modification of defaults.
+    Default behavior is to use zlib compression
+  
+  Returns
+  -------
+  None
+  """
+  logging.info("Reading input")
+  # This may actually take a while if the observations haven't
+  # already been read.
+  obs_sets = list(obs_sets)
+  # the list of all epochs in the observation set
+  epochs = [x['epoch'] for x in obs_sets]
+  def build_df(group_name, obs_sets):
+    # Creates a list of tuples, the first element is the epoch
+    # and the second is the observation for group_name at that epoch
+    # any epochs without observations are skipped
+    pieces = [(np.repeat(e, x[group_name].shape[0]), x[group_name])
+              for e, x in zip(epochs, obs_sets)
+              if group_name in x]
+    # Concatenates observations into a single data frame
+    # and creates a multiindex which makes iteration
+    df = pd.concat([y for _, y in pieces])
+    epoch_index = np.concatenate([y for y, _ in pieces])
+    assert df.index.name is not None
+    # reorganize so the index is epoch and the current index
+    df.index = pd.MultiIndex.from_arrays([epoch_index, df.index],
+                                         names=['epoch', df.index.name])
+    # epoch has been added to the index, if it's a col get rid of it.
+    if 'epoch' in df:
+      df.drop('epoch', axis=1, inplace=True)
+    return df
+
+  store_args = {'complevel': 5, 'complib': 'zlib'}
+  store_args.update(kwdargs)
+  with pd.HDFStore(output_path, mode='w', **store_args) as hdf:
+    logging.info("Concatenating into DataFrames")
+    def add_group(key):
+      df = build_df(key, obs_sets)
+      hdf.put(key, df)
+      # Next we check if there is a corresponding _info field for the
+      # key.  If so we make sure it's unique before adding them as
+      # attributes.
+      info_name = '%s_info' % key
+      # read all the information dictionaries and make sure they're unique
+      info = np.unique([x.get(info_name, None) for x in obs_sets])
+      if info.size > 1:
+        logging.warn("Ambiguous attributes found in %s" % info_name)
+        if strict:
+          raise ValueError("Expected unique attributes in %s" % info_name)
+      info = info[0]
+      if info is not None:
+        # Write attributes
+        hdf.get_storer(key).attrs.info = info
+
+    logging.info("Writting to file %s" % output_path)
+    # Get all the keys in the full set of obs_sets
+    groups = reduce(lambda x, y: x.union(y), [set(x.keys()) for x in obs_sets])
+    # the remove any of the info keys, those will be processesed sererately
+    groups = [x for x in groups if not x.endswith('_info')]
+    groups.pop(groups.index('epoch'))
+    # and write to file.
+    [add_group(k) for k in groups]
+
+
+def read_group(hdf5_store, group_name):
+  """
+  Reads a single group and it's (optional) attributes from an
+  HDF5 store and returns them in a format suitable for using
+  simulate.simulate_from_iterables.
+  """
+  def iter_obs():
+    for _, one_epoch in hdf5_store[group_name].groupby(level='epoch'):
+      old_index = one_epoch.index.names[1]
+      one_epoch.reset_index(inplace=True)
+      one_epoch.set_index(old_index, inplace=True)
+      yield one_epoch
+
+  info = getattr(hdf5_store.get_storer(group_name).attrs, 'info', {})
+  return info, iter_obs()

--- a/gnss_analysis/synthetic.py
+++ b/gnss_analysis/synthetic.py
@@ -111,7 +111,6 @@ def observation(ephemerides, location_ecef, toa,
   obs['ref_z'] = location_ecef[2]
   obs['ref_t'] = toa
   obs['ref_rover_clock_error'] = rover_clock_error
-
   return obs
 
 

--- a/tests/test_ephemeris.py
+++ b/tests/test_ephemeris.py
@@ -17,7 +17,7 @@ def test_calc_sat_state(ephemerides):
   version of calc_sat_state matches the c implementation.
   """
   n = ephemerides.shape[0]
-  time = ephemerides['time'].copy()
+  time = np.max(ephemerides['toc'].values) + np.timedelta64(10, 's')
   noise = 1e-3 * np.random.normal(size=n)
   time += time_utils.timedelta_from_seconds(noise)
 
@@ -30,10 +30,10 @@ def test_calc_sat_state(ephemerides):
     eph = ephemerides.iloc[[i]]
     eph_obj = observations.mk_ephemeris(eph.reset_index())
     # compute the distance to satellite at the time of observation
-    wn_tow = time_utils.datetime_to_tow(time.values[i])
+    wn_tow = time_utils.datetime_to_tow(time[i])
     gpst = gpstime.GpsTime(**wn_tow)
     expected = eph_obj.calc_sat_state(gpst)
-    another = ephemeris.calc_sat_state(eph, time.iloc[[i]])
+    another = ephemeris.calc_sat_state(eph, time[i])
     act = actual.iloc[[i], :]
 
     # make sure bulk and individual sat state error computations
@@ -56,7 +56,7 @@ def test_calc_sat_state(ephemerides):
 
 
 def test_sagnac_rotation(ephemerides):
-  time = ephemerides['time'].copy()
+  time = np.max(ephemerides['toc'].values) + np.timedelta64(10, 's')
   n = ephemerides.shape[0]
   noise = 40 + 1e-3 * np.random.normal(size=n)
   time += time_utils.timedelta_from_seconds(noise)
@@ -126,8 +126,8 @@ def test_add_satellite_state(ephemerides):
   """
   Makes sure that add_satellite_state performs as expected
   """
-  ref_time = ephemerides.iloc[0]['time']
-  ref_time = ref_time.to_datetime64() + time_utils.timedelta_from_seconds(40)
+  ref_time = np.max(ephemerides['toc'].values) + np.timedelta64(10, 's')
+  ref_time = ref_time + time_utils.timedelta_from_seconds(40)
 
   # make some random transmission times
   np.random.seed(1982)
@@ -202,7 +202,7 @@ def test_time_of_flight(ephemerides):
   for tof_func in [ephemeris.time_of_flight_from_tot,
                    ephemeris.time_of_flight_from_toa]:
 
-    ref_time = ephemerides.iloc[0]['time'].to_datetime64()
+    ref_time = np.max(ephemerides['toc'].values) + np.timedelta64(10, 's')
     ref_time += time_utils.timedelta_from_seconds(40)
     ref_loc = locations.NOVATEL_ABSOLUTE
 
@@ -234,7 +234,7 @@ def test_time_of_roundtrip(ephemerides):
   backs out the time of transmission to make sure it matches.
   """
   n = ephemerides.shape[0]
-  tot = ephemerides['time'].copy()
+  tot = np.max(ephemerides['toc'].values) + np.timedelta64(10, 's')
   noise = np.random.normal(0.1, 0.1, size=n)
   tot += 40 + time_utils.timedelta_from_seconds(noise)
   ref_loc = locations.NOVATEL_ABSOLUTE
@@ -256,7 +256,7 @@ def test_sat_velocity(ephemerides):
   # computes a set of satellite states, then uses the state
   # velocity to predict the state at a nearby time and compares
   # it to the actual sat state at that time.
-  ref_time = ephemerides.iloc[0]['time']
+  ref_time = np.max(ephemerides['toc'].values) + np.timedelta64(10, 's')
   ref_time += time_utils.timedelta_from_seconds(40)
 
   sat_state = ephemeris.calc_sat_state(ephemerides, ref_time)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,89 @@
+import os
+import copy
+import pytest
+import tempfile
+import itertools
+import numpy as np
+import pandas as pd
+
+from gnss_analysis import ephemeris
+from gnss_analysis.io import hdf5
+from gnss_analysis.io import simulate
+
+
+@pytest.fixture(params=['raw', 'add_state', 'solution'])
+def observations_and_solutions(observation_sets,
+                               request):
+
+  if request.param == 'raw':
+    return observation_sets
+  elif request.param == 'add_state':
+    # Add satellite state to the observations and return a new generator
+    def add_state(obs_set):
+      obs_set['rover'] = ephemeris.add_satellite_state(obs_set['rover'],
+                                                       obs_set['ephemeris'])
+      if 'base' in obs_set:
+        obs_set['base'] = ephemeris.add_satellite_state(obs_set['base'],
+                                                         obs_set['ephemeris'])
+      return obs_set
+
+    return (add_state(obs_set) for obs_set in observation_sets)
+  elif request.param == "solution":
+    from gnss_analysis import solution
+    from gnss_analysis.filters import StaticKalmanFilter
+    return solution.solution(observation_sets, StaticKalmanFilter())
+  else:
+    raise NotImplementedError("Unknown param %s" % request.param)
+
+
+def dict_equal(x, y):
+  # make sure each dictionary has the same keys
+  assert not len(set(x.keys()).symmetric_difference(set(y.keys())))
+  # then make sure the values are the same
+  for (k, v) in x.iteritems():
+    # using np.all allows the values to be lists/arrays and still
+    # be properly comparable.
+    assert np.all(y[k] == v)
+
+
+@pytest.mark.slow
+def test_roundtrip_to_hdf5(observations_and_solutions,
+                           datadir):
+  """
+  Reads from a piksi log, dumps to HDF5 then loads
+  back and makes sure the two observation set iterators
+  are identical.
+  """
+  tmp_file = os.path.basename(tempfile.mktemp(suffix='.hdf5'))
+  output_path = datadir.join(tmp_file).strpath
+  # only use the first 10 observation sets
+  obs_sets = [x for _, x in zip(range(10), observations_and_solutions)]
+  # make a copy of them so we aren't accidentally modifying them
+  # before comparison
+  obs_sets_copy = copy.deepcopy(obs_sets)
+  # save the copy to hdf5
+  hdf5.to_hdf5(obs_sets_copy, output_path)
+  # and then pull them back out of hdf5
+  hdf5_sets = [x for x in simulate.simulate_from_hdf5(output_path)]
+  # and make sure we haven't changed anything
+  for expected, actual in itertools.izip_longest(obs_sets, hdf5_sets):
+    for k in expected.keys():
+      if k.endswith('_info'):
+        info_name = '%s_info' % k
+        if info_name in expected:
+          dict_equal(expected[info_name], actual[info_name])
+        else:
+          assert info_name not in actual
+      else:
+        if isinstance(expected[k], pd.DataFrame):
+          # sometimes the columns are shuffled, which we don't care about,
+          # so first we make sure the column sets are the same.  Note
+          # that we only care if all the expected values are contained
+          # in the actual ones.  If actual contains some extra columns
+          # that is considered OK.
+          assert not expected[k].columns.difference(actual[k].columns).size
+          # then we reorder and compare
+          pd.util.testing.assert_frame_equal(expected[k],
+                                             actual[k][expected[k].columns])
+        else:
+          np.testing.assert_array_equal(expected[k], actual[k])

--- a/tests/test_kalman_filter.py
+++ b/tests/test_kalman_filter.py
@@ -3,11 +3,10 @@ import numpy as np
 
 from gnss_analysis.filters import kalman_filter
 
-@pytest.mark.parametrize('filter_class', [kalman_filter.StaticKalmanFilter,
-                                          kalman_filter.DynamicKalmanFilter])
+
 @pytest.mark.parametrize("drop_ref", [True, False])
-def test_kalman_drops_sat(synthetic_stationary_states,
-                          drop_ref, filter_class):
+def test_kalman_drops_sat(synthetic_stationary_observations,
+                          drop_ref, dgnss_filter_class):
   """
   Runs through several epochs of data running three filters
   side by side.  One filter receives all the observations,
@@ -17,11 +16,12 @@ def test_kalman_drops_sat(synthetic_stationary_states,
   The baselines are compared, but allowed to vary slightly.
   """
   np.random.seed(1982)
-  epochs = [x for _, x in zip(range(10), synthetic_stationary_states)]
+  epochs = [x for _, x in zip(range(10),
+                              synthetic_stationary_observations)]
 
-  expected_filter = filter_class()
-  everyother_filter = filter_class()
-  simultaneous_filter = filter_class()
+  expected_filter = dgnss_filter_class()
+  everyother_filter = dgnss_filter_class()
+  simultaneous_filter = dgnss_filter_class()
 
   for i, epoch in enumerate(epochs):
     expected_filter.update(epoch)
@@ -62,9 +62,8 @@ def test_kalman_drops_sat(synthetic_stationary_states,
     np.testing.assert_allclose(expected_bl, actual_bl, atol=1e-3)
     np.testing.assert_allclose(expected_bl, simul_bl, atol=1e-2)
 
-@pytest.mark.parametrize('filter_class', [kalman_filter.StaticKalmanFilter,
-                                          kalman_filter.DynamicKalmanFilter])
-def test_kalman_change_reference_sat(synthetic_stationary_states, filter_class):
+def test_kalman_change_reference_sat(synthetic_stationary_observations,
+                                     dgnss_filter_class):
   """
   This runs through several epochs of data and performs a
   few sanity checks.  In particular it checks that changing
@@ -73,11 +72,12 @@ def test_kalman_change_reference_sat(synthetic_stationary_states, filter_class):
   cause the solution at all.
   """
   np.random.seed(1982)
-  epochs = [x for _, x in zip(range(10), synthetic_stationary_states)]
+  epochs = [x for _, x in zip(range(10),
+                              synthetic_stationary_observations)]
 
-  expected_filter = filter_class()
-  actual_filter = filter_class()
-  roundtrip_filter = filter_class()
+  expected_filter = dgnss_filter_class()
+  actual_filter = dgnss_filter_class()
+  roundtrip_filter = dgnss_filter_class()
 
   for epoch in epochs:
     expected_filter.update(epoch)

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -11,20 +11,18 @@ import mock
 import pytest
 import numpy as np
 
-import sbp.observation as ob
-
 from sbp.msg import SBP
 from sbp.client.loggers.json_logger import JSONLogIterator
 
 from gnss_analysis import log_utils
 
 
-def test_runs(jsonlog):
+def test_runs(piksi_log_path):
   """
   Straight forward test that simply makes sure the test log can
   be parsed without failure.
   """
-  for msg, data in log_utils.complete_messages_only(jsonlog.next()):
+  for msg, data in log_utils.complete_messages_only(piksi_log_path):
     pass
 
 
@@ -65,7 +63,7 @@ def test_is_split_message():
     assert log_utils.is_split_message(msg) == expected
 
 
-def test_log_iterator(jsonlogpath):
+def test_log_iterator(piksi_log_path):
   """
   Make sure log_iterator returns an iterator over messages
   and data if you pass in a path, log_iterator or log_iterator.next()
@@ -76,12 +74,12 @@ def test_log_iterator(jsonlogpath):
     assert isinstance(msg, SBP)
     assert isinstance(data, dict)
 
-  assert_is_log_iterator(log_utils.log_iterator(jsonlogpath))
+  assert_is_log_iterator(log_utils.log_iterator(piksi_log_path))
 
-  with JSONLogIterator(jsonlogpath) as log:
+  with JSONLogIterator(piksi_log_path) as log:
     assert_is_log_iterator(log_utils.log_iterator(log))
 
-  with JSONLogIterator(jsonlogpath) as log:
+  with JSONLogIterator(piksi_log_path) as log:
     assert_is_log_iterator(log_utils.log_iterator(log.next()))
 
 

--- a/tests/test_propagate.py
+++ b/tests/test_propagate.py
@@ -18,7 +18,7 @@ def test_delta_tof_for_known_position(ephemerides):
   """
   location_ecef = locations.NOVATEL_ABSOLUTE
 
-  first_toa = ephemerides['time'] + np.timedelta64(100, 's')
+  first_toa = np.max(ephemerides['toc'].values) + np.timedelta64(100, 's')
   first = synthetic.observation(ephemerides, location_ecef,
                                 first_toa)
   # we don't account for satellite error here because tot is in system time

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -4,47 +4,39 @@ import numpy as np
 
 from gnss_analysis.io import simulate
 
-@pytest.fixture
-def sbp_log_simulator(jsonlog):
-  return simulate.simulate_from_log(jsonlog)
 
-@pytest.fixture
-def rinex_simulator(rinex_observation, rinex_navigation, rinex_base):
-  return simulate.simulate_from_rinex(rinex_observation,
-                                      rinex_navigation,
-                                      rinex_base)
-
-# TODO: There has to be a way to parameterize this with py.test,
-#   but I can't figure it out.
-def test_simulators(sbp_log_simulator,
-                    rinex_simulator):
+def test_simulators(observation_sets):
   """
   A quick and dirty test that just makes sure a simulator runs
   without failing and that each iteration is a copy, but doesn't
   check any of the actual content.
   """
-  for obs_sets in [sbp_log_simulator, rinex_simulator]:
-    prev_obs_set = obs_sets.next()
-    obs_sets = [x for _, x in zip(range(10), obs_sets)]
-    expected_keys = set(['rover', 'base', 'ephemeris', 'epoch',
-                         'rover_info', 'base_info', 'ephemeris_info'])
-    for obs_set in obs_sets:
-      # make sure all the expected keys are keys in the obs_set
-      assert not len(expected_keys.difference(obs_set.keys()))
+  prev_obs_set = observation_sets.next()
+  obs_sets = [x for _, x in zip(range(10), observation_sets)]
+  # note that sometimes we don't have base observations, so it isn't
+  # a required key
+  expected_keys = set(['rover', 'ephemeris', 'epoch',
+                       'rover_info', 'base_info', 'ephemeris_info'])
+  for obs_set in obs_sets:
+    # make sure all the expected keys are keys in the obs_set
+    assert not len(expected_keys.difference(obs_set.keys()))
 
-      # now make sure we can modify fields in the obs_set without impacting
-      # others.
-      obs_set_copy = copy.deepcopy(obs_set)
-      keys = ['rover', 'base', 'ephemeris']
-      for k in keys:
-        prev_v_copy = copy.deepcopy(prev_obs_set[k])
-        # fill with nans
-        obs_set[k].ix[:] = np.nan
-        # make sure modifying the current state won't
-        # alter the previous state.  We have to compare
-        # by iterating over each column since each column
-        # may be a different data type.
-        for (_, x), (_, y) in zip(prev_obs_set[k].iteritems(),
-                                  prev_v_copy.iteritems()):
-          np.testing.assert_array_equal(x.values, y.values)
-      prev_obs_set = obs_set_copy
+    # now make sure we can modify fields in the obs_set without impacting
+    # others.
+    obs_set_copy = copy.deepcopy(obs_set)
+    for k in [k for k in obs_set.keys() if not k.endswith('_info')]:
+      # scalars can't be updated in place, so no need to worry about them.
+      # also skip this if an observation type wasn't seen before
+      if np.isscalar(obs_set[k]) or k not in prev_obs_set:
+        continue
+      prev_v_copy = copy.deepcopy(prev_obs_set[k])
+      # fill with nans
+      obs_set[k].ix[:] = np.nan
+      # make sure modifying the current state won't
+      # alter the previous state.  We have to compare
+      # by iterating over each column since each column
+      # may be a different data type.
+      for (_, x), (_, y) in zip(prev_obs_set[k].iteritems(),
+                                prev_v_copy.iteritems()):
+        np.testing.assert_array_equal(x.values, y.values)
+    prev_obs_set = obs_set_copy

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -11,7 +11,7 @@ def test_observation(ephemerides):
   by synthetic.observation are in accordance with RINEX
   defined observation types.
   """
-  toa = ephemerides['time'].values[0] + np.timedelta64(10, 's')
+  toa = np.max(ephemerides['toc'].values) + np.timedelta64(10, 's')
 
   obs = synthetic.observation(ephemerides,
                               locations.NOVATEL_ABSOLUTE,
@@ -53,8 +53,7 @@ def test_observation(ephemerides):
 
 
 def test_piksi_like_observation(ephemerides):
-
-  toa = ephemerides['time'].values[0] + np.timedelta64(10, 's')
+  toa = np.max(ephemerides['toc'].values) + np.timedelta64(10, 's')
 
   obs = synthetic.piksi_like_observation(ephemerides,
                                          locations.NOVATEL_ABSOLUTE,


### PR DESCRIPTION
This change will allow us to do things like:
- Parse RINEX/SBP observations, compute satellite state and save to HDF5.
- Run observation sets through a filter and save the observations and position solutions to HDF5
- Iterate through data stored in an HDF5 file the same way we would with observations directly from RINEX/SBP.

Also includes:
 - More thorough testing using pytest.parameterize.
 - Observation sets now include info dictionaries.
 - Solution thread returns DataFrames instead of dicts to allow serialization to HDF5.

@swift-nav/estimation 