### PR TITLE
Run fast tests first, then slow ones.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,8 @@ install:
   - pip install -e ./
 
 script:
-  - py.test tests/
+  - py.test -m "not slow" tests/
+  - py.test -m "slow" tests/
 
 after_success:
   - coveralls


### PR DESCRIPTION
This will make the travis build fail faster.

@benjamin0 