### PR TITLE
Reorganize Tests, add tests for convert.py

### DIFF
--- a/examples/example_filter_run.py
+++ b/examples/example_filter_run.py
@@ -51,7 +51,6 @@ if __name__ == "__main__":
   # collect all the baseline errors
   errors = [compute_baseline_error(soln) for soln in solutions]
   # and make a plot
-  sns.set_style('darkgrid')
   plt.plot(errors)
   plt.xlabel("Epoch")
   plt.ylabel("actual - expected (m)")

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ INSTALL_REQUIRES = ['cython',
                     # or can be installed from a local clone of
                     # libswiftnav.
                     'swiftnav',
+                    'progressbar'
                     ]
 TEST_REQUIRES = ['pytest', 'mock']
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,47 @@
+import os
+import pytest
+import argparse
+
+from gnss_analysis.tools import convert
+
+@pytest.fixture(params=['cors', 'piksi'])
+def input_observations(request, datadir):
+  def get_path(x):
+    return datadir.join(x).strpath
+  if request.param == 'cors':
+    return ('%(rover)s --navigation %(nav)s --base %(base)s'
+            % {'rover': get_path('cors_drops_reference/seat032/partial_seat0320.16o'),
+               'nav': get_path('cors_drops_reference/seat032/seat0320.16n'),
+               'base': get_path('cors_drops_reference/ssho032/partial_ssho0320.16o')
+              })
+  elif request.param == 'piksi':
+    return get_path('partial_serial-link-20151221-142236.log.json')
+
+
+@pytest.fixture(params=['default', 'partial', 'filter', 'add_state'])
+def options(request):
+  if request.param == 'default':
+    return ''
+  elif request.param == 'partial':
+    return '-n 10'
+  elif request.param == 'filter':
+    return '-n 10 --filter static'
+  elif request.param == 'add_state':
+    return '-n 10 --calc-sat-state'
+
+
+def test_converts_piksi(datadir, input_observations, options):
+
+  parser = argparse.ArgumentParser()
+  parser = convert.create_parser(parser)
+
+  full_args = ' '.join([input_observations, options])
+  args = parser.parse_args(full_args.split())
+  args = convert.post_process(args)
+
+  convert.convert(args)
+
+  # make sure the output file was created and is nonzero
+  assert os.path.exists(args.output)
+  assert os.path.getsize(args.output)
+


### PR DESCRIPTION
No change in functionality, just improvements to tests:
- Reorganized test coverage to further take advantage of parametrizaiton.
- Added a test for `convert.py`

@swift-nav/estimation 