### PR TITLE
Travis (actually) fails faster.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,7 @@ install:
   - pip install -e ./
 
 script:
-  - py.test -m "not slow" tests/
-  - py.test -m "slow" tests/
+  - py.test -m "not slow" tests/ && py.test -m "slow" tests/
 
 after_success:
   - coveralls


### PR DESCRIPTION
If the non-slow travis tests fail, stop the travis build before trying the slow ones.