### PR TITLE
Properly handle stray line returns in RINEX parsing.

### DIFF
--- a/gnss_analysis/io/rinex.py
+++ b/gnss_analysis/io/rinex.py
@@ -501,8 +501,7 @@ def build_observation_parser(header):
 
   def parser(lines):
     # grab the next `n_lines` lines and join them into one
-    joined = ''.join(lines.next() for i in range(n_lines))
-    joined = joined.replace('\n', '')
+    joined = ''.join([lines.next() for i in range(n_lines)])
     # then parse it into observations
     funcs = itertools.cycle([float_or_nan, int_or_zero, int_or_zero])
     obs = np.array([f(o) for f, o in zip(funcs, obs_parser(joined))])
@@ -763,7 +762,8 @@ def iter_padded_lines(file_or_path, pad=80):
   else:
     lines = iter(file_or_path)
 
-  return (('{: <%d}' % pad).format(l) for l in lines)
+  for l in lines:
+    yield ('{: <%d}' % pad).format(l.rstrip('\n'))
 
 
 def infer_navigation_path(observation_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,12 +157,14 @@ def cors_short_baseline(datadir):
   base = datadir.join('short_baseline_cors/ssho032/ssho0320.16o').strpath
   return rinex_observation_sets(rover, nav, base)
 
+
 @pytest.fixture
 def multignss_cors_35km_baseline(datadir):
   rover = datadir.join('multignss_cors_L2C_35km_baseline/cebr049a00.16o').strpath
   nav = datadir.join('multignss_cors_L2C_35km_baseline/cebr049a00.16n').strpath
   base = datadir.join('multignss_cors_L2C_35km_baseline/vill049a00.16o').strpath
   return rinex_observation_sets(rover, nav, base)
+
 
 @pytest.fixture
 def rinex_210(datadir):


### PR DESCRIPTION
A stray linefeed in the multignss RINEX files was causing the signal strength to get bumped over and erroneously read as a lock indicator.

@benjamin0 